### PR TITLE
Identifier regexp improvements (support TOML and Org ID)

### DIFF
--- a/denote-link.el
+++ b/denote-link.el
@@ -100,7 +100,7 @@ files."
 (defconst denote-link--title-regexp "^\\(#\\+\\)?\\(title:\\)[\s\t]+\\(.*\\)"
   "Regular expression for title key and value.")
 
-(defconst denote-link--identifier-regexp "^\\(#\\+\\)?\\(identifier:\\)[\s\t]+\\(.*\\)"
+(defconst denote-link--identifier-regexp "^.?.?\\b\\(identifier\\|ID\\)\\s-*[:=]\\s-*\"?\\([0-9T]+\\)"
   "Regular expression for filename key and value.")
 
 (defconst denote-link--link-format-org "[[file:%s][%s (%s)]]"

--- a/denote-link.el
+++ b/denote-link.el
@@ -95,13 +95,19 @@ files."
   "Return value from REGEXP by searching the file."
   (goto-char (point-min))
   (re-search-forward regexp)
-  (match-string-no-properties 3))
+  (match-string-no-properties 1))
 
-(defconst denote-link--title-regexp "^\\(#\\+\\)?\\(title:\\)[\s\t]+\\(.*\\)"
-  "Regular expression for title key and value.")
+(defconst denote-link--title-regexp "^\\(?:#\\+\\)?\\(?:title:\\)[\s\t]+\\(?1:.*\\)"
+  "Regular expression for title key and value.
 
-(defconst denote-link--identifier-regexp "^.?.?\\b\\(identifier\\|ID\\)\\s-*[:=]\\s-*\"?\\([0-9T]+\\)"
-  "Regular expression for filename key and value.")
+The match that needs to be extracted is explicityly marked as
+group 1.  `denote-link--find-value' uses the group 1 sting.")
+
+(defconst denote-link--identifier-regexp "^.?.?\\b\\(?:identifier\\|ID\\)\\s-*[:=]\\s-*\"?\\(?1:[0-9T]+\\)"
+  "Regular expression for filename key and value.
+
+The match that needs to be extracted is explicityly marked as
+group 1.  `denote-link--find-value' uses the group 1 sting.")
 
 (defconst denote-link--link-format-org "[[file:%s][%s (%s)]]"
   "Format of Org link to note.")

--- a/denote-link.el
+++ b/denote-link.el
@@ -94,7 +94,7 @@ files."
 (defun denote-link--find-value (regexp)
   "Return value from REGEXP by searching the file."
   (goto-char (point-min))
-  (re-search-forward regexp)
+  (re-search-forward regexp nil nil 1) ;Stop search after the first match
   (match-string-no-properties 1))
 
 (defconst denote-link--title-regexp "^\\(?:#\\+\\)?\\(?:title:\\)[\s\t]+\\(?1:.*\\)"


### PR DESCRIPTION
Fixes issue 10 over at the Github mirror:
<https://github.com/protesilaos/denote/issues/10>.

This regexp update now also matches the ID property. Refer issue 8 at
the Github mirror: <https://github.com/protesilaos/denote/issues/8>.