### PR TITLE
refactor: Default Org front-matter to use the ID property 

### DIFF
--- a/README.org
+++ b/README.org
@@ -485,36 +485,38 @@ derived automatically.
 
 This is how it looks for Org mode (~denote-file-type~ is nil):
 
-#+begin_example
-#+title:      This is a sample note
-#+date:       2022-06-10
-#+filetags:   denote  testing
-#+identifier: 20220610T202537
-#+end_example
+#+begin_src org
+:PROPERTIES:
+:ID: 20220610T202537
+:END:
+,#+title:      This is a sample note
+,#+date:       2022-06-10
+,#+filetags:   denote  testing
+#+end_src
 
 For Markdown with YAML, it looks like this (~denote-file-type~ has the
 =markdown-yaml= value):
 
-#+begin_example
+#+begin_src md
 ---
 title:      "This is a sample note"
 date:       2022-06-10
 tags:       denote  testing
 identifier: "20220610T202021"
 ---
-#+end_example
+#+end_src
 
 For Markdown with TOML, it looks like this (~denote-file-type~ has the
 =markdown-toml= value):
 
-#+begin_example
+#+begin_src md
 +++
 title      = "This is a sample note"
 date       = 2022-06-10
 tags       = ["denote", "testing"]
 identifier = "20220610T201510"
 +++
-#+end_example
+#+end_src
 
 And for plain text, we have the following (~denote-file-type~ has the
 =text= value):
@@ -567,10 +569,12 @@ what we have in =denote.el=:
 
 #+begin_src emacs-lisp
 (defvar denote-org-front-matter
-  "#+title:      %s
+  ":PROPERTIES:
+:ID:          %4$s
+:END:
+#+title:      %s
 #+date:       %s
 #+filetags:   %s
-#+identifier: %s
 \n"
   "Org front matter value for `format'.
 The order of the arguments is TITLE, DATE, KEYWORDS, ID.  If you
@@ -579,43 +583,46 @@ how front matter is produced, consider using something like %2$s
 to control where Nth argument is placed.")
 #+end_src
 
-The default front matter is:
+Notice how we can pass a number to the =%s= specifier for the =:ID:=
+property.  This is what allows us to change the placement of the
+provided arguments.
 
-#+begin_example
-#+title:      This is a sample note
-#+date:       2022-06-10
-#+filetags:   denote  testing
-#+identifier: 20220610T202537
-#+end_example
+The default Org mode front matter is formatted as:
 
-We can add a =PROPERTIES= drawer to it, with something like this:
+#+begin_src org
+:PROPERTIES:
+:ID: 20220610T202537
+:END:
+,#+title:      This is a sample note
+,#+date:       2022-06-10
+,#+filetags:   denote  testing
+#+end_src
+
+If the user does not need =org-id= compatible ID property drawer, they
+can do this instead:
 
 #+begin_src emacs-lisp
 (setq denote-org-front-matter
-      ":PROPERTIES:
-:ID: %4$s
-:END:
-#+title:      %1$s
-#+date:       %2$s
-#+filetags:   %3$s
-#+identifier: %4$s
-\n")
+      "#+title:     %s
+,#+date:       %s
+,#+filetags:   %s
+,#+identifier: %s
+\n"
+      "Org front matter value for `format'.
+The order of the arguments is TITLE, DATE, KEYWORDS, ID.  If you
+are an avdanced user who wants to edit this variable to affect
+how front matter is produced, consider using something like %2$s
+to control where Nth argument is placed.")
 #+end_src
 
 The output is now formatted thus:
 
-#+begin_example
-:PROPERTIES:
-:ID: 20220611T092444
-:END:
-#+title:      This is a sample note
-#+date:       2022-06-11
-#+filetags:   denote  testing
-#+identifier: 20220611T092444
-#+end_example
-
-Notice how we can pass a number to the =%s= specifier.  This is what
-allows us to change the placement of the provided arguments.
+#+begin_src org
+,#+title:      This is a sample note
+,#+date:       2022-06-10
+,#+filetags:   denote  testing
+,#+identifier: 20220610T202537
+#+end_src
 
 For another example, we will use the plain text variant, as it differs a
 bit from the above.  By default it is formatted this way:

--- a/denote-link.el
+++ b/denote-link.el
@@ -190,6 +190,23 @@ and/or the documentation string of `display-buffer'."
                alist)
   :group 'denote-link)
 
+(defcustom denote-link-use-org-id nil
+  "When non-nil use the ID link type in Org files.
+
+Newly created links will use the standard `id:' hyperlink type
+instead of the custom `denote:' type.
+
+In practical terms, the ID ensures maximum compatibility with the
+Org ecosystem.
+
+When the value is nil, Denote links rely on the custom `denote:'
+type (which should behave the same as the standard `file:' type).
+
+Other files types beside Org always use the `denote:' links."
+  :type 'boolean
+  :group 'denote-link)
+;;;###autoload (put 'denote-link-use-org-id 'safe-local-variable 'booleanp)
+
 ;;;; Link to note
 
 ;; Arguments are: FILE-ID FILE-TITLE
@@ -197,7 +214,7 @@ and/or the documentation string of `display-buffer'."
   "Format of Org link to note.")
 
 (defconst denote-link--format-org-with-id "[[id:%s][%s]]"
-  "Format of Org link to note for `denote-use-org-id'.")
+  "Format of Org link to note for `denote-link-use-org-id'.")
 
 (defconst denote-link--format-markdown "[%2$s](denote:%1$s)"
   "Format of Markdown link to note.")
@@ -216,7 +233,7 @@ and/or the documentation string of `display-buffer'."
 
 (defun denote-link--file-type-format (file)
   "Return link format based on FILE format."
-  (let ((org-format (if denote-use-org-id
+  (let ((org-format (if denote-link-use-org-id
                         denote-link--format-org-with-id
                       denote-link--format-org)))
     (pcase (file-name-extension file)

--- a/denote-link.el
+++ b/denote-link.el
@@ -196,6 +196,9 @@ and/or the documentation string of `display-buffer'."
 (defconst denote-link--format-org "[[denote:%s][%s]]"
   "Format of Org link to note.")
 
+(defconst denote-link--format-org-with-id "[[id:%s][%s]]"
+  "Format of Org link to note for `denote-use-org-id'.")
+
 (defconst denote-link--format-markdown "[%2$s](denote:%1$s)"
   "Format of Markdown link to note.")
 
@@ -203,7 +206,7 @@ and/or the documentation string of `display-buffer'."
   "Format of identifier-only link to note.")
 
 (defconst denote-link--regexp-org
-  (concat "\\[\\[" "denote:"  "\\(?1:" denote--id-regexp "\\)" "]" "\\[.*?]]"))
+  (concat "\\[\\[" "\\(denote\\|[Ii][Dd]\\):"  "\\(?1:" denote--id-regexp "\\)" "]" "\\[.*?]]"))
 
 (defconst denote-link--regexp-markdown
   (concat "\\[.*?]" "(denote:"  "\\(?1:" denote--id-regexp "\\)" ")"))
@@ -213,9 +216,12 @@ and/or the documentation string of `display-buffer'."
 
 (defun denote-link--file-type-format (file)
   "Return link format based on FILE format."
-  (pcase (file-name-extension file)
-    ("md" denote-link--format-markdown)
-    (_ denote-link--format-org))) ; Includes backup files.  Maybe we can remove them?
+  (let ((org-format (if denote-use-org-id
+                        denote-link--format-org-with-id
+                      denote-link--format-org)))
+    (pcase (file-name-extension file)
+      ("md" denote-link--format-markdown)
+      (_ org-format)))) ; Includes backup files.  Maybe we can remove them?
 
 (defun denote-link--file-type-regexp (file)
   "Return link regexp based on FILE format."

--- a/denote-retrieve.el
+++ b/denote-retrieve.el
@@ -39,7 +39,7 @@ The match that needs to be extracted is explicityly marked as
 group 1.")
 
 (defconst denote-retrieve--identifier-regexp
-  "^.?.?\\b\\(?:identifier\\|ID\\)\\s-*[:=]\\s-*[\"']?\\(?1:[0-9T]+\\)[\"']?"
+  "^.?.?\\b\\(?:identifier\\|[Ii][Dd]\\)\\s-*[:=]\\s-*[\"']?\\(?1:[0-9T]+\\)[\"']?"
   "Regular expression for identifier key and value.
 The match that needs to be extracted is explicityly marked as
 group 1.")

--- a/denote.el
+++ b/denote.el
@@ -211,6 +211,25 @@ is suspended: we use whatever the user wants."
           (string :tag "Custom format for `format-time-string'"))
   :group 'denote)
 
+(defcustom denote-use-org-id nil
+  "When non-nil use the ID property and link type in Org files.
+To use the ID property, a PROPERTIES drawer is added to the top
+of newly created notes.  Furthermore, newly created links will
+use the standard 'id:' hyperlink type instead of the custom
+'denote:' type.
+
+In practical terms, the ID ensures maximum compatibility with the
+Org ecosystem.
+
+When the value is nil, Denote uses a generic front matter for new
+notes and links rely on the custom 'denote:' type (which should
+behave the same as the standard 'file:' type).
+
+Other files types beside Org always use the 'denote:' links and
+keep their generic front matter."
+  :type 'boolean
+  :group 'denote)
+
 ;;;; Main variables
 
 (defconst denote--id-format "%Y%m%dT%H%M%S"
@@ -246,6 +265,8 @@ We consider those characters illigal for our purposes.")
         `(metadata (category . ,category))
       (complete-with-action action candidates string pred))))
 
+(defvar org-id-extra-files)
+
 (defun denote-directory ()
   "Return path of variable `denote-directory' as a proper directory."
   (let* ((val (or (buffer-local-value 'denote-directory (current-buffer))
@@ -253,6 +274,8 @@ We consider those characters illigal for our purposes.")
          (path (if (or (eq val 'default-directory) (eq val 'local)) default-directory val)))
     (unless (file-directory-p path)
       (make-directory path t))
+    (when (and denote-use-org-id (require 'org-id nil t))
+      (setq org-id-extra-files (directory-files path nil "\.org$")))
     (file-name-as-directory path)))
 
 (defun denote--extract (regexp str &optional group)
@@ -508,6 +531,16 @@ and do not use any empty line before it.
 These help ensure consistency and might prove useful if we need
 to operate on the front matter as a whole.")
 
+(defvar denote-org-with-id-front-matter
+  ":PROPERTIES:
+:ID:          %4$s
+:END:
+#+title:      %1$s
+#+date:       %2$s
+#+filetags:   %3$s
+\n"
+  "Like `denote-org-front-matter' but for `denote-use-org-id'.")
+
 (defun denote--file-meta-header (title date keywords id &optional filetype)
   "Front matter for new notes.
 
@@ -517,12 +550,13 @@ TITLE, DATE, KEYWORDS, FILENAME, ID are all strings which are
 Optional FILETYPE is one of the values of `denote-file-type',
 else that variable is used."
   (let ((kw-space (denote--file-meta-keywords keywords))
-        (kw-toml (denote--file-meta-keywords keywords 'toml)))
+        (kw-toml (denote--file-meta-keywords keywords 'toml))
+        (org-front (if denote-use-org-id denote-org-with-id-front-matter denote-org-front-matter)))
     (pcase (or filetype denote-file-type)
       ('markdown-toml (format denote-toml-front-matter title date kw-toml id))
       ('markdown-yaml (format denote-yaml-front-matter title date kw-space id))
       ('text (format denote-text-front-matter title date kw-space id denote-text-front-matter-delimiter))
-      (_ (format denote-org-front-matter title date kw-space id)))))
+      (_ (format org-front title date kw-space id)))))
 
 (defun denote--path (title keywords &optional dir id)
   "Return path to new file with TITLE and KEYWORDS.


### PR DESCRIPTION
- Move `denote-use-org-id` from denote.el to `denote-link-use-org-id` in denote-link.el. The rationale for this change is that the ID property style will always work for Org files and doesn't need any customization; also that style doesn't add any org-id dependency.
- The org-id dependency is needed only if the user wants to access "active" feature of the "id:" type links like following and exporting.

Fixes https://github.com/protesilaos/denote/issues/8.