### PR TITLE
When a note title ends with `)`, denote-retrieve--title-front-matter-regexp does not capture the `)`.

### DIFF
--- a/denote-dired.el
+++ b/denote-dired.el
@@ -284,7 +284,7 @@ TITLE, DATE, KEYWORDS, FILENAME, ID, and FILETYPE are all strings
   "Return likely file type of FILE.
 The return value is for `denote--file-meta-header'."
   (pcase (file-name-extension file)
-    ("md" (if (string-match-p "title\\s-*=" (denote-retrieve--value-title file 0))
+    ("md" (if (string-match-p "title\\s-*=" (denote-retrieve--value-title file t))
               'markdown-toml
             'markdown-yaml))
     ("txt" 'text)


### PR DESCRIPTION
I was planning on opening an issue, but I was able to fix it.

Example:
```
#+title:        My Note (good)
```
The regexp captures `My Note (good` (without the `)`).

I could fix this by removing `\\b` from the regexp (but it breaks validation of double quotes around titles), but after reading Emacs manual on regexp, I still don't understand why it does not work with `\\b`. Also, the following similar examples give different results:

Example 1:
```
string: "good)%@"
regexp: "good.*\\b"
match: "good)%"        ;  "@" excluded
```
Example 2:
```
string: "good)&@"      ;  like Example1, but & instead of %
regexp: "good.*\\b"
match: "good"          ;  ")&@" excluded
```

I have tried to make it work by tweaking the regexp, but I was not successful. Then, I tried to rework the code a little and I think I got something simpler in the process.

Summary of my pull request:
- The regexps have been modified to focus only on the key part of the line. The value part is easy to retrieve once the key is matched. We just need to trim (of spaces and quotes) the remainder of the line. The regexp notion of GROUP will not be needed anymore.

In details:
- `denote-retrieve--value` has been removed. `denote-retrieve--search` is doing all the work. Given a KEY-REGEXP, it retrieves the value part of the matching line. With optional KEY argument, it retrieves the key part instead.
- I have been careful to retain all functionalities while removing some complexity. The code is also a little shorter.
- It fixes the bug above and it might prevent other issues from the complex regexps.

Let me know if you want to merge it. And how should I do the FSF copyright assignment?