### PR TITLE
Support subdirectories

### DIFF
--- a/denote-link.el
+++ b/denote-link.el
@@ -312,9 +312,13 @@ format is always [[denote:IDENTIFIER]]."
 
 (defun denote-link--expand-identifiers (regexp)
   "Expend identifiers matching REGEXP into file paths."
-  (delq nil (mapcar (lambda (i)
-                      (file-name-completion i (denote-directory)))
-                    (denote-link--collect-identifiers regexp))))
+  (let ((files (denote--directory-files))
+        (found-files))
+    (dolist (file files)
+      (dolist (i (denote-link--collect-identifiers regexp))
+        (if (string-prefix-p i (file-name-nondirectory file))
+            (push file found-files))))
+    found-files))
 
 (defvar denote-link--find-file-history nil
   "History for `denote-link-find-file'.")
@@ -442,16 +446,16 @@ Use optional TITLE for a prettier heading."
                   (l (length heading)))
         (insert (format "%s\n%s\n\n" heading (make-string l ?-))))
       (mapc (lambda (f)
-              (insert (file-name-nondirectory f))
+              (insert f)
               (make-button (point-at-bol) (point-at-eol) :type 'denote-link-backlink-button)
               (newline))
             files)
-      (goto-char (point-min))
+      (goto-char (point-min)))
       ;; NOTE 2022-06-15: Technically this is not Dired.  Maybe we
       ;; should abstract the fontification into a general purpose
       ;; minor-mode.
-      (when denote-link-fontify-backlinks
-        (denote-dired-mode 1)))
+      ;(when denote-link-fontify-backlinks
+        ;(denote-dired-mode 1)))
     (denote-link--display-buffer buf)))
 
 ;;;###autoload

--- a/denote-retrieve.el
+++ b/denote-retrieve.el
@@ -90,7 +90,8 @@ Optional GROUP is a regexp construct for
 
 (defun denote-retrieve--read-file-prompt ()
   "Prompt for regular file in variable `denote-directory'."
-  (read-file-name "Select note: " (denote-directory) nil nil nil #'denote--only-note-p))
+  (read-file-name "Select note: " (denote-directory) nil nil nil
+                  #'(lambda (f) (or (denote--only-note-p f) (file-directory-p f)))))
 
 (defun denote-retrieve--files-in-output (files)
   "Return list of FILES from `find' output."
@@ -109,14 +110,14 @@ The xrefs are returned as an alist."
 Parse `denote-retrieve--xrefs'."
   (sort
    (mapcar (lambda (x)
-             (file-name-nondirectory (car x)))
+             (denote--file-name-relative-to-denote-directory (car x)))
            xrefs)
    #'string-lessp))
 
 (defun denote-retrieve--proces-grep (identifier)
   "Process lines matching IDENTIFIER and return list of files."
   (let* ((default-directory (denote-directory))
-         (file (file-name-nondirectory (buffer-file-name))))
+         (file (denote--file-name-relative-to-denote-directory (buffer-file-name))))
     (denote-retrieve--files-in-output
      (delete file (denote-retrieve--files-in-xrefs
                    (denote-retrieve--xrefs identifier))))))


### PR DESCRIPTION
Summary:
- In `denote-directory-files`, I replaced `directory-files` with `directory-files-recursively`.
- The new function `denote--file-relative-to-denote-directory` is used to fix the backlinks buffer and other parts of the code. You should now be able to see files like "subdir/20220628T111111--Note__tag.org" in the backlinks buffer.

Tests I have made:
- Backlinks buffer displays links in subdirectories. Clicking on them works.
- `denote-link` allows navigation in subdirectories (and only displays actual notes like before).
- Renaming a note still works. Inferred tags are all found.

Still to do:
- Test other parts of the code, notably `denote-link-ol-export` and `denote-link--ol-resolve-link-to-target`.
- Fix fontification for the backlinks buffer. There is a comment in the code saying that enabling `dired-denote-mode` might not be the best way to enable fontification. I don't know how it works. I have just commented that code. A temporary solution to not break existing setups is to enable `dired-denote-mode` only if there are no subdirectories and defer that feature for later.
- Review `denote-link--expand-identifiers`. There might be a better way to do this.

Question:
- I have been thinking: What would a user option `denote-excluded-subdirectories` actually be useful for? I mean the command `denote-link` already ignores anything that is not a note. I expect others commands to behave similarly (ignore non-notes). So, excluded subdirectories are already supported!

(I will notify you when I get the final confirmation from the FSF.)