### PR TITLE
Set default-value to previous title in denote--title-prompt

### DIFF
--- a/denote-dired.el
+++ b/denote-dired.el
@@ -231,10 +231,11 @@ This command is intended to (i) rename existing Denote
 notes, (ii) complement note-taking, such as by renaming
 attachments that the user adds to their notes."
   (interactive
-   (list
-    (denote-dired--rename-file-is-regular (denote-dired--rename-dired-file-or-prompt))
-    (denote--title-prompt)
-    (denote--keywords-prompt)))
+   (let ((file (denote-dired--rename-file-is-regular (denote-dired--rename-dired-file-or-prompt))))
+     (list
+      file
+      (denote--title-prompt (denote-retrieve--value-title file))
+      (denote--keywords-prompt))))
   (let* ((dir (file-name-directory file))
          (old-name (file-name-nondirectory file))
          (extension (file-name-extension file t))

--- a/denote.el
+++ b/denote.el
@@ -631,10 +631,15 @@ used to construct the path's identifier."
 (defvar denote--title-history nil
   "Minibuffer history of `denote--title-prompt'.")
 
-(defun denote--title-prompt ()
-  "Read file title for `denote'."
-  (setq denote-last-title
-        (read-string "File title: " nil 'denote--title-history)))
+(defun denote--title-prompt (&optional default-title)
+  "Read file title for `denote'.
+
+Optional DEFAULT-TITLE is used as the default value."
+  (let ((format (if default-title
+                    (format " File title [%s]: " default-title)
+                  "File title: ")))
+    (setq denote-last-title
+          (read-string format nil 'denote--title-history default-title))))
 
 ;;;###autoload
 (defun denote (title keywords)


### PR DESCRIPTION
I have been holding one last pull request until all other would be closed.

When I rename a note, it is often just to fix a typo in the title or change the wording. I rarely have to modify the whole title. This pull request just sets the `DEFAULT-VALUE` parameter of `read-string` in `denote--title-prompt` to the previous title instead of `nil` when using the command `denote-dired-rename-file`.

An empty input will just use the previous title. This would be useful if you just want to update the tags.
When prompted for a title, using `M-n` allows for editing of the previous title.