### PR TITLE
Remove "/" from denote-directory path in denote--subdirs-prompt

### DIFF
--- a/denote.el
+++ b/denote.el
@@ -813,7 +813,7 @@ The TITLE and KEYWORDS arguments are the same as with `denote'."
 
 (defun denote--subdirs-prompt ()
   "Handle user input on choice of subdirectory."
-  (let* ((root (denote-directory))
+  (let* ((root (directory-file-name (denote-directory)))
          (subdirs (denote--subdirs))
          (dirs (push root subdirs)))
     (denote--subdirs-completion-table dirs)))


### PR DESCRIPTION
We need to remove the trailing "/" from the denote-directory path in `denote--subdirs-prompt` or else it cannot be selected.