### PR TITLE
More refactors to remove the big regexp

### DIFF
--- a/denote-faces.el
+++ b/denote-faces.el
@@ -83,14 +83,17 @@ and seconds."
   :group 'denote-faces)
 
 (defconst denote-faces-file-name-keywords
-  `((,denote--file-regexp
+  `((,denote--id-regexp
      (1 'denote-faces-date)
-     (2 'denote-faces-time)
-     (3 'denote-faces-delimiter)
-     (4 'denote-faces-title)
-     (5 'denote-faces-delimiter)
-     (6 'denote-faces-keywords)
-     (7 'denote-faces-extension))
+     (2 'denote-faces-time))
+    (,denote--title-regexp
+     (1 'denote-faces-title))
+    (,denote--keywords-regexp
+     (1 'denote-faces-keywords))
+    (,denote--extension-regexp
+     (0 'denote-faces-extension))
+    ("--"
+     (0 'denote-faces-delimiter t))
     ("_"
      (0 'denote-faces-delimiter t)))
   "Keywords for fontification of file names.")

--- a/denote.el
+++ b/denote.el
@@ -239,19 +239,14 @@ are described in the doc string of `format-time-string'."
 (defconst denote--id-regexp "\\([0-9]\\{8\\}\\)\\(T[0-9]\\{6\\}\\)"
   "Regular expression to match `denote--id-format'.")
 
+(defconst denote--title-regexp "--\\([0-9A-Za-z-]*\\)"
+  "Regular expression to match keywords.")
+
 (defconst denote--keywords-regexp "__\\([0-9A-Za-z_-]*\\)"
   "Regular expression to match keywords.")
 
 (defconst denote--extension-regexp "\\.\\(org\\|md\\|txt\\)"
   "Regular expression to match supported Denote extensions.")
-
-(defconst denote--file-title-regexp
-  (concat denote--id-regexp "\\(--\\)\\(.*\\)\\(__\\)")
-  "Regular expression to match file names from `denote'.")
-
-(defconst denote--file-regexp
-  (concat denote--file-title-regexp "\\([0-9A-Za-z_-]*\\)\\(\\.?.*\\)")
-  "Regular expression to match the entire file name'.")
 
 (defconst denote--punctuation-regexp "[][{}!@#$%^&*()_=+'\"?,.\|;:~`‘’“”/]*"
   "Regular expression of punctionation that should be removed.

--- a/denote.el
+++ b/denote.el
@@ -242,6 +242,9 @@ are described in the doc string of `format-time-string'."
 (defconst denote--keywords-regexp "__\\([0-9A-Za-z_-]*\\)"
   "Regular expression to match keywords.")
 
+(defconst denote--extension-regexp "\\.\\(org\\|md\\|txt\\)"
+  "Regular expression to match supported Denote extensions.")
+
 (defconst denote--file-title-regexp
   (concat denote--id-regexp "\\(--\\)\\(.*\\)\\(__\\)")
   "Regular expression to match file names from `denote'.")
@@ -249,10 +252,6 @@ are described in the doc string of `format-time-string'."
 (defconst denote--file-regexp
   (concat denote--file-title-regexp "\\([0-9A-Za-z_-]*\\)\\(\\.?.*\\)")
   "Regular expression to match the entire file name'.")
-
-(defconst denote--file-only-note-regexp
-  (concat denote--file-regexp "\\.\\(org\\|md\\|txt\\)")
-  "Regular expression to match the entire file name of a note file.")
 
 (defconst denote--punctuation-regexp "[][{}!@#$%^&*()_=+'\"?,.\|;:~`‘’“”/]*"
   "Regular expression of punctionation that should be removed.
@@ -321,10 +320,13 @@ trailing hyphen."
 (defun denote--only-note-p (file)
   "Make sure FILE is an actual Denote note.
 FILE is relative to the variable `denote-directory'."
-  (and (not (file-directory-p file))
-       (file-regular-p file)
-       (string-match-p denote--file-only-note-regexp file)
-       (not (string-match-p "[#~]\\'" file))))
+  (let ((file-name (file-name-nondirectory file)))
+    (and (not (file-directory-p file))
+         (file-regular-p file)
+         (string-match-p (concat "\\`" denote--id-regexp
+                                 ".*" denote--extension-regexp "\\'")
+                         file-name)
+         (not (string-match-p "[#~]\\'" file)))))
 
 (defun denote--file-name-relative-to-denote-directory (file)
   "Return file name of FILE relative to the variable `denote-directory'.


### PR DESCRIPTION
This pull request contains:

- Removal of `denote--keywords-in-files`. It was not doing much and it was only used by `denote--inferred-keywords` (which I have refactored a little).
- Refactor of `denote--extract` into `denote--extract-keywords-from-path`. Since we want to move away from a single big regexp, the function `denote--extract` would not be useful anymore.
  - `denote--extract-keywords-from-path` is implemented using `string-match` while `denote--extract` was creating a temp buffer for the string and using `re-search-forward`. Any reason why it was implemented that way?
- Refactor of `denote--only-note-p` to remove the use of denote--file-only-note-regexp. Instead we can just check if the file name starts with an ID and ends with a Denote extension. Everything inbetween is unchecked.

I did not understand the font locking variables in `dired-faces.el`, so I was not able to change it. That is the only thing remaining before we can delete `denote--file-title-regexp` and `denote--file-regexp`.