### PR TITLE
Remove else part in denote--file-name-relative-to-denote-directory

### DIFF
--- a/denote.el
+++ b/denote.el
@@ -370,11 +370,11 @@ FILE is relative to the variable `denote-directory'."
 (defun denote--file-name-relative-to-denote-directory (file)
   "Return file name of FILE relative to the variable `denote-directory'.
 FILE must be an absolute path."
-  (if-let* ((dir (denote-directory))
-            ((file-name-absolute-p file))
-            ((string-prefix-p dir file)))
-      (substring-no-properties file (length dir))
-    file))
+  (when-let* ((dir (denote-directory))
+              ((file-name-absolute-p file))
+              (file-name (expand-file-name file))
+              ((string-prefix-p dir file-name)))
+    (substring-no-properties file-name (length dir))))
 
 (defun denote--current-file-is-note-p ()
   "Return non-nil if current file likely is a Denote note."


### PR DESCRIPTION
We have had this discussion before, but the else part in the `if-let*` in `denote--file-name-relative-to-denote-directory` does not seem necessary. You mentioned that you had issues coming from `xref` without it. I find this strange, but I added `expand-file-name` just to be sure. That is the only thing I would imagine that could lead to the else part being executed. You should test your backlinks just to be sure!