### PR TITLE
Specify existing face for backlink buttons.

### DIFF
--- a/denote-link.el
+++ b/denote-link.el
@@ -367,10 +367,13 @@ positions, limit the process to the region in-between."
 
 ;;;; Backlinks' buffer
 
+(defface denote-link--backlink-button nil
+  "Face for backlink buttons.")
+
 (define-button-type 'denote-link-backlink-button
   'follow-link t
   'action #'denote-link--backlink-find-file
-  'face 'unspecified)     ; we use this face attribute to style it later
+  'face 'denote-link--backlink-button)     ; we use this face attribute to style it later
 
 (defun denote-link--backlink-find-file (button)
   "Action for BUTTON to `find-file'."


### PR DESCRIPTION
This is an old minor bug.

I get this in `*Messages*` whenever the backlinks buffer is open:

```
Invalid face reference: unspecified [1331 times]
```

Nothing was broken though. This pull request removes the messages.