### PR TITLE
Expand file name of denote-directory

### DIFF
--- a/denote.el
+++ b/denote.el
@@ -274,7 +274,7 @@ We consider those characters illigal for our purposes.")
          (path (if (or (eq val 'default-directory) (eq val 'local)) default-directory val)))
     (unless (file-directory-p path)
       (make-directory path t))
-    (file-name-as-directory path)))
+    (file-name-as-directory (expand-file-name path))))
 
 (defun denote--slug-no-punct (str)
   "Convert STR to a file name slug."


### PR DESCRIPTION
I was sure the function `denote-directory` was returning the expanded file name, but as reported in issue #43, it is not the case.

This pull request fixes that.