### PR TITLE
Renaming functions

### DIFF
--- a/denote-dired.el
+++ b/denote-dired.el
@@ -422,11 +422,11 @@ Rename marked files in Dired using the following pattern:
 Batch renaming ignores files that comply with Denote's
 file-naming scheme."
   (interactive nil dired-mode)
-  (if-let ((marks (dired-get-marked-files)))
+  (if-let ((marks (dired-get-marked-files))
+           (keywords (denote--keywords-prompt)))
       (progn
         (dolist (file marks)
-          (let* ((keywords (denote--keywords-prompt))
-                 (dir (file-name-directory file))
+          (let* ((dir (file-name-directory file))
                  (id (denote-dired--file-name-id file))
                  (title (or (denote-retrieve--value-title file)
                             (file-name-sans-extension
@@ -434,8 +434,8 @@ file-naming scheme."
                  (extension (file-name-extension file t))
                  (new-name (denote--format-file
                             dir id keywords (denote--sluggify title) extension)))
-            (unless (denote--only-note-p file)
-              (rename-file (file-name-nondirectory file) new-name))))
+            (when (denote--only-note-p file)
+              (rename-file file new-name))))
         (revert-buffer))
     (user-error "No marked files; aborting")))
 

--- a/denote-dired.el
+++ b/denote-dired.el
@@ -434,8 +434,7 @@ file-naming scheme."
                  (extension (file-name-extension file t))
                  (new-name (denote--format-file
                             dir id keywords (denote--sluggify title) extension)))
-            (when (denote--only-note-p file)
-              (rename-file file new-name))))
+            (rename-file file new-name)))
         (revert-buffer))
     (user-error "No marked files; aborting")))
 

--- a/denote-dired.el
+++ b/denote-dired.el
@@ -357,7 +357,7 @@ attachments that the user adds to their notes."
 
 ;;;###autoload
 (defun denote-dired-rename-file-and-add-front-matter (file title keywords)
-  "Convert a file to Denote format.
+  "Rename FILE and add a front matter.
 
 Prompt for a FILE, a TITLE, and KEYWORDS.  The unique identifier
 is retrieved from the filename if there is one, else the last

--- a/denote-dired.el
+++ b/denote-dired.el
@@ -352,6 +352,9 @@ attachments that the user adds to their notes."
     (when (denote-dired--rename-file file new-name)
       (denote-dired--rewrite-front-matter new-name title keywords))))
 
+(defalias 'denote-dired-rename-file
+  (symbol-function 'denote-dired-rename-file-and-rewrite-front-matter))
+
 ;;;###autoload
 (defun denote-dired-rename-file-and-add-front-matter (file title keywords)
   "Convert a file to Denote format.

--- a/denote-dired.el
+++ b/denote-dired.el
@@ -143,6 +143,29 @@ old name followed by the new one."
   :type 'boolean
   :group 'denote-dired)
 
+(defcustom denote-dired-post-rename-functions
+  (list #'denote-dired-update-dired-buffers
+        #'denote-dired--rewrite-front-matter)
+  "List of functions called after `denote-dired-rename-file'.
+Each function must accept three arguments: FILE, TITLE, and
+KEYWORDS.  The first is the full path to the file provided as a
+string, the second is the human-readable file name (not what
+Denote sluggifies) also as a string, and the third are the
+keywords.  If there is only one keyword, it is a string, else a
+list of strings.
+
+DEVELOPMENT NOTE: the `denote-dired-rewrite-front-matter' needs
+to be tested thoroughly.  It rewrites file contents so we have to
+be sure it does the right thing.  To avoid any trouble, it always
+asks for confirmation before performing the replacement.  This
+confirmation ignores `denote-dired-rename-expert' for the time
+being, though we might want to lift that restriction once
+everything works as intended."
+  :type 'hook
+  :group 'denote-dired)
+
+(make-obsolete 'denote-dired-post-rename-functions nil "0.4.0")
+
 ;;;; File helper functions
 
 (defun denote-dired--file-attributes-time (file)

--- a/denote-dired.el
+++ b/denote-dired.el
@@ -187,20 +187,19 @@ everything works as intended."
       (set-visited-file-name new-name nil t))))
 
 (defun denote-dired--rename-dired-file-or-prompt ()
-  "Return Dired file at point, else prompt for one."
+  "Return Dired file at point, else prompt for one.
+
+Throw error is FILE is not regular, else return FILE."
   (or (dired-get-filename nil t)
       (let* ((file (buffer-file-name))
              (format (if file
                          (format "Rename file Denote-style [%s]: " file)
-                       "Rename file Denote-style: ")))
-        (read-file-name format nil file t nil))))
-
-(defun denote-dired--rename-file-is-regular (file)
-  "Throw error is FILE is not regular, else return FILE."
-  (if (or (file-directory-p file)
-          (not (file-regular-p file)))
-      (user-error "Only rename regular files")
-    file))
+                       "Rename file Denote-style: "))
+             (selected-file (read-file-name format nil file t nil)))
+        (if (or (file-directory-p selected-file)
+                (not (file-regular-p selected-file)))
+            (user-error "Only rename regular files")
+          selected-file))))
 
 ;;;###autoload
 (defun denote-dired-rename-file (file title keywords)
@@ -232,7 +231,7 @@ This command is intended to (i) rename existing Denote
 notes, (ii) complement note-taking, such as by renaming
 attachments that the user adds to their notes."
   (interactive
-   (let ((file (denote-dired--rename-file-is-regular (denote-dired--rename-dired-file-or-prompt))))
+   (let ((file (denote-dired--rename-dired-file-or-prompt)))
      (list
       file
       (denote--title-prompt (denote-retrieve--value-title file))
@@ -381,7 +380,7 @@ For per-file-type front matter, refer to the variables:
 - `denote-toml-front-matter'
 - `denote-yaml-front-matter'"
   (interactive
-   (let ((file (denote-dired--rename-file-is-regular (denote-dired--rename-dired-file-or-prompt))))
+   (let ((file (denote-dired--rename-dired-file-or-prompt)))
      (list
       file
       (denote--title-prompt (or (denote-retrieve--value-title file)

--- a/denote-dired.el
+++ b/denote-dired.el
@@ -143,27 +143,6 @@ old name followed by the new one."
   :type 'boolean
   :group 'denote-dired)
 
-(defcustom denote-dired-post-rename-functions
-  (list #'denote-dired-update-dired-buffers
-        #'denote-dired-rewrite-front-matter)
-  "List of functions called after `denote-dired-rename-file'.
-Each function must accept three arguments: FILE, TITLE, and
-KEYWORDS.  The first is the full path to the file provided as a
-string, the second is the human-readable file name (not what
-Denote sluggifies) also as a string, and the third are the
-keywords.  If there is only one keyword, it is a string, else a
-list of strings.
-
-DEVELOPMENT NOTE: the `denote-dired-rewrite-front-matter' needs
-to be tested thoroughly.  It rewrites file contents so we have to
-be sure it does the right thing.  To avoid any trouble, it always
-asks for confirmation before performing the replacement.  This
-confirmation ignores `denote-dired-rename-expert' for the time
-being, though we might want to lift that restriction once
-everything works as intended."
-  :type 'hook
-  :group 'denote-dired)
-
 ;;;; Commands
 
 (defun denote-dired--file-attributes-time (file)
@@ -253,7 +232,8 @@ attachments that the user adds to their notes."
                      (propertize (file-name-nondirectory new-name) 'face 'success)))
         (rename-file old-name new-name nil)
         (denote-dired--rename-buffer old-name new-name)
-        (run-hook-with-args 'denote-dired-post-rename-functions new-name title keywords)))))
+        (denote-dired-update-dired-buffers)
+        (denote-dired-rewrite-front-matter new-name title keywords)))))
 
 (defun denote-dired-update-dired-buffers (&rest _)
   "Update Dired buffers of variable `denote-directory'.

--- a/denote-dired.el
+++ b/denote-dired.el
@@ -235,10 +235,8 @@ attachments that the user adds to their notes."
         (denote-dired-update-dired-buffers)
         (denote-dired-rewrite-front-matter new-name title keywords)))))
 
-(defun denote-dired-update-dired-buffers (&rest _)
-  "Update Dired buffers of variable `denote-directory'.
-Can run after `denote-dired-post-rename-functions', though it
-ignores all its arguments."
+(defun denote-dired-update-dired-buffers ()
+  "Update Dired buffers of variable `denote-directory'."
   (mapc
    (lambda (buf)
      (with-current-buffer buf

--- a/denote-dired.el
+++ b/denote-dired.el
@@ -241,8 +241,8 @@ attachments that the user adds to their notes."
    (lambda (buf)
      (with-current-buffer buf
        (when (and (eq major-mode 'dired-mode)
-                  (string-match-p (expand-file-name default-directory)
-                                  (expand-file-name (denote-directory))))
+                  (string-prefix-p (denote-directory)
+                                   (expand-file-name default-directory)))
          (revert-buffer))))
    (buffer-list)))
 

--- a/denote-dired.el
+++ b/denote-dired.el
@@ -375,8 +375,10 @@ attachments that the user adds to their notes."
     (when (denote-dired--rename-file file new-name)
       (denote-dired--rewrite-front-matter new-name title keywords))))
 
-(defalias 'denote-dired-rename-file
-  (symbol-function 'denote-dired-rename-file-and-rewrite-front-matter))
+(define-obsolete-function-alias
+  'denote-dired-rename-file
+  'denote-dired-rename-file-and-rewrite-front-matter
+  "0.4.0")
 
 ;;;###autoload
 (defun denote-dired-rename-file-and-add-front-matter (file title keywords)
@@ -420,6 +422,11 @@ For per-file-type front matter, refer to the variables:
          (max-mini-window-height 0.33)) ; allow minibuffer to be resized
     (when (denote-dired--rename-file file new-name)
       (denote-dired--add-front-matter new-name title keywords id))))
+
+(define-obsolete-function-alias
+  'denote-dired-convert-file-to-denote
+  'denote-dired-rename-file-and-add-front-matter
+  "0.4.0")
 
 ;;;###autoload
 (defun denote-dired-rename-marked-files ()

--- a/denote-retrieve.el
+++ b/denote-retrieve.el
@@ -56,19 +56,20 @@
 (defun denote-retrieve--search (file key-regexp &optional key)
   "Return value of KEY-REGEXP key in current buffer from FILE.
 If optional KEY is non-nil, return the key instead."
-  (with-temp-buffer
-    (insert-file-contents file)
-    (save-excursion
-      (save-restriction
-        (widen)
-        (goto-char (point-min))
-        (when (re-search-forward key-regexp nil t 1)
-          (if key
-              (match-string-no-properties 0)
-            (let ((trims "[ \t\n\r\"']+"))
-              (string-trim
-               (buffer-substring-no-properties (point) (point-at-eol))
-               trims trims))))))))
+  (when (denote--only-note-p file)
+    (with-temp-buffer
+      (insert-file-contents file)
+      (save-excursion
+        (save-restriction
+          (widen)
+          (goto-char (point-min))
+          (when (re-search-forward key-regexp nil t 1)
+            (if key
+                (match-string-no-properties 0)
+              (let ((trims "[ \t\n\r\"']+"))
+                (string-trim
+                 (buffer-substring-no-properties (point) (point-at-eol))
+                 trims trims)))))))))
 
 (defun denote-retrieve--value-title (file &optional key)
   "Return title value from FILE.


### PR DESCRIPTION
> DEV NOTE 2022-07-16: proof of concept---help flesh it out.

Ok!

What would you say about these proposed functions (for more precision)?

```elisp
(defun denote-dired-rename-file-and-rewrite-front-matter (file title keywords) ...)
    ; Same as the old `denote-dired-rename-file`. I added it as an alias. We could also deprecate it.
(defun denote-dired-rename-file-and-add-front-matter (file title keywords) ...)
    ; Same as the old `denote-dired-convert-file-to-denote`
(defun denote-dired-rename-marked-files () ...)
    ; Same as your new `denote-dired-batch-rename`.
```

- In all of them, marked files are used.
- In my pull request, they are all implemented similarly. Since we specify that `denote-dired-rename-file-and-rewrite-front-matter` rewrites the front matter, it does not make sense to have it be part of a user option `denote-dired-post-rename-functions`. I added an hyphen in the name of `denote-dired--rewrite-front-matter` to make it internal.
- The other function `denote-dired-update-dired-buffers` in `denote-dired-post-rename-functions` is called directly as part the new internal function `denote-dired--rename-file`. This leaves nothing in the user option `denote-dired-post-rename-functions`. This pull request removes it.
- In `denote-dired-rename-marked-files`, I have added the code to retrieve the title from a line starting with `#+title:`. I know it must open the files and it can be slow, but since it is a command meant for interactive use, I am not sure the user will select that many files.
- I moved the functions around and I renamed the two sections of the code: `File helper functions` and `Renaming commands`.

This is just a proof-of-concept to show you what this could look like and get your feedback. You don't have to merge it.