### PR TITLE
Renaming commands, minor adjustments

### DIFF
--- a/denote-dired.el
+++ b/denote-dired.el
@@ -472,7 +472,7 @@ file-naming scheme."
     (user-error "No marked files; aborting")))
 
 ;;;###autoload
-(defun denote-dired-rename-marked-files-and-add-front-matter ()
+(defun denote-dired-rename-marked-files-and-add-front-matters ()
   "DEV NOTE 2022-07-17: proof of concept---help flesh it out.
 
 Like `denote-dired-rename-marked-files' but also adds front

--- a/denote-dired.el
+++ b/denote-dired.el
@@ -319,7 +319,8 @@ appropriate."
 The TITLE, KEYWORDS and ID are passed from the renaming
 command and are used to construct a new front matter block if
 appropriate."
-  (when-let* ((filetype (denote-dired--filetype-heuristics file))
+  (when-let* ((denote--only-note-p file)
+              (filetype (denote-dired--filetype-heuristics file))
               (date (denote--date (date-to-time id)))
               (new-front-matter (denote--file-meta-header title date keywords id filetype)))
     (with-current-buffer (find-file-noselect file)
@@ -499,8 +500,7 @@ doc string)."
                             dir id keywords (denote--sluggify title) extension)))
             (rename-file file new-name)
             (denote-dired--rename-buffer file new-name)
-            (when (denote--only-note-p file)
-              (denote-dired--add-front-matter new-name title keywords id))))
+            (denote-dired--add-front-matter new-name title keywords id)))
         (revert-buffer))
     (user-error "No marked files; aborting")))
 


### PR DESCRIPTION
I moved the check for `denote--only-note-p` in `denote-dired--add-front-matter`.

I added an `s` to `denote-dired-rename-marked-files-and-add-front-matters`. Does it make sense?