### PR TITLE
Refactor denote--prepare-notes and other modifications

### DIFF
--- a/denote-org-capture.el
+++ b/denote-org-capture.el
@@ -91,7 +91,9 @@ Consult the manual for template samples."
         (keywords (denote--keywords-prompt))
         (denote-file-type nil)) ; we enforce the .org extension for `org-capture'
     (denote--path title keywords)
-    (denote--prepare-note denote-last-title denote-last-keywords denote-last-path)
+    (setq denote-last-front-matter (denote--file-meta-header
+                                    title (denote--date nil) keywords
+                                    (format-time-string denote--id-format nil)))
     (denote--keywords-add-to-history denote-last-keywords)
     (concat denote-last-front-matter denote-org-capture-specifiers)))
 

--- a/denote.el
+++ b/denote.el
@@ -827,11 +827,13 @@ is set to \\'(file-type title keywords)."
   (mapcar
    (lambda (name)
      (file-name-nondirectory name))
-   (delq nil
-         (mapcar
-          (lambda (buf)
-            (buffer-file-name buf))
-          (buffer-list)))))
+   (seq-filter
+    (lambda (name) (denote--only-note-p name))
+    (delq nil
+          (mapcar
+           (lambda (buf)
+             (buffer-file-name buf))
+           (buffer-list))))))
 
 (declare-function cl-some "cl-extra" (cl-pred cl-seq &rest cl-rest))
 

--- a/denote.el
+++ b/denote.el
@@ -687,23 +687,20 @@ With optional DATE, use it else use the current one."
      (t
       (denote--date-org-timestamp date)))))
 
-(defun denote--prepare-note (title keywords &optional path date id)
-  "Use TITLE and KEYWORDS to prepare new note file.
-Use optional PATH, else create it with `denote--path'.  When PATH
-is provided, refrain from writing to a buffer (useful for org
-capture).
+(defun denote--prepare-note (title keywords date id directory file-type)
+  "Prepare a new note file.
 
-Optional DATE is passed to `denote--date', while optional ID is
-used to construct the path's identifier."
-  (let* ((default-directory (denote-directory))
-         (p (or path (denote--path title keywords default-directory id)))
-         (buffer (unless path (find-file p)))
+Arguments TITLE, KEYWORDS, DATE, ID, DIRECTORY, and FILE-TYPE
+should be valid for note creation."
+  (let* ((default-directory directory)
+         (path (denote--path title keywords default-directory id))
+         (buffer (find-file path))
          (header (denote--file-meta-header
                   title (denote--date date) keywords
-                  (format-time-string denote--id-format date))))
-    (unless path
-      (with-current-buffer buffer (insert header))
-      (setq denote-last-buffer buffer))
+                  (format-time-string denote--id-format date)
+                  file-type)))
+    (with-current-buffer buffer (insert header))
+    (setq denote-last-buffer buffer)
     (setq denote-last-front-matter header)))
 
 (defvar denote--title-history nil
@@ -763,15 +760,16 @@ When called from Lisp, all arguments are optional.
          ('subdirectory (aset args 3 (denote--subdirs-prompt)))
          ('date (aset args 4 (denote--date-prompt)))))
      (append args nil)))
-  (let* ((denote-file-type (denote--file-type-symbol (or file-type denote-file-type)))
+  (let* ((file-type (denote--file-type-symbol (or file-type denote-file-type)))
          (date (if (or (null date) (string-empty-p date))
                    (current-time)
                  (denote--valid-date date)))
          (id (format-time-string denote--id-format date))
-         (denote-directory (or (denote--dir-in-denote-directory-p subdirectory)
-                               (denote-directory))))
+         (directory (if (denote--dir-in-denote-directory-p subdirectory)
+                        (file-name-nondirectory subdirectory)
+                      (denote-directory))))
     (denote--barf-duplicate-id id)
-    (denote--prepare-note (or title "") keywords nil date id)
+    (denote--prepare-note (or title "") keywords date id directory file-type)
     (denote--keywords-add-to-history keywords)))
 
 (defalias 'denote-create-note (symbol-function 'denote))

--- a/denote.el
+++ b/denote.el
@@ -825,6 +825,19 @@ is set to \\'(file-type title keywords)."
   "Return DATE if parsed by `date-to-time', else signal error."
   (date-to-time date))
 
+(defun denote--buffer-file-names ()
+  "Return file names of active buffers."
+  (mapcar
+   (lambda (name)
+     (file-name-nondirectory name))
+   (delq nil
+         (mapcar
+          (lambda (buf)
+            (buffer-file-name buf))
+          (buffer-list)))))
+
+(declare-function cl-some "cl-extra" (cl-pred cl-seq &rest cl-rest))
+
 ;; This should only be relevant for `denote-date', otherwise the
 ;; identifier is always unique (we trust that no-one writes multiple
 ;; notes within fractions of a second).
@@ -832,7 +845,11 @@ is set to \\'(file-type title keywords)."
   "Return non-nil if IDENTIFIER already exists.
 NO-CHECK-CURRENT passes the appropriate flag to
 `denote--directory-files-matching-regexp'."
-  (denote--directory-files-matching-regexp identifier no-check-current))
+  (or (cl-some (lambda (file)
+                 (string-match-p (concat "\\`" identifier) file))
+               (denote--buffer-file-names))
+      (denote--directory-files-matching-regexp
+       (concat "\\`" identifier) no-check-current)))
 
 (defun denote--barf-duplicate-id (identifier)
   "Throw a user-error if IDENTIFIER already exists else return t."

--- a/denote.el
+++ b/denote.el
@@ -721,8 +721,8 @@ Optional DEFAULT-TITLE is used as the default value."
 (defun denote--dir-in-denote-directory-p (directory)
   "Return DIRECTORY if in variable `denote-directory', else nil."
   (when-let* ((dir directory)
-              ((string-match-p (expand-file-name (denote-directory))
-                               (expand-file-name dir))))
+              ((string-prefix-p (expand-file-name (denote-directory))
+                                (expand-file-name dir))))
     dir))
 
 ;;;###autoload

--- a/denote.el
+++ b/denote.el
@@ -763,7 +763,7 @@ When called from Lisp, all arguments are optional.
                  (denote--valid-date date)))
          (id (format-time-string denote--id-format date))
          (directory (if (denote--dir-in-denote-directory-p subdirectory)
-                        (file-name-nondirectory subdirectory)
+                        (file-name-as-directory subdirectory)
                       (denote-directory))))
     (denote--barf-duplicate-id id)
     (denote--prepare-note (or title "") keywords date id directory file-type)


### PR DESCRIPTION
`denote--prepare-note` is only used in 2 places: in `denote` and for org-capture. In `denote`, we let-bind `denote-file-type` and `denote-directory`. In this pull request, I remove the let-binding and pass the file-type and the directory directly to `denote--prepare-note`.

For org-capture, I noticed that the only thing `denote--prepare-note` was doing is set `denote-last-front-matter`.

---

`denote--id-exists-p` should also check the active buffers because a new note might not be saved yet.

---

I added 2 internals functions: `denote--get-all-used-ids` and `denote--find-first-available-id`. They are not used anywhere yet, but maybe they can be used to solve the collision issues.

---

I do not understand why we use `:no-check-current` in `denote--barf-duplicate-id`. Why is it needed?