### PR TITLE
Cleanup of denote.el

### DIFF
--- a/denote.el
+++ b/denote.el
@@ -424,8 +424,6 @@ FILE must be an absolute path."
            (string-match-p denote--id-regexp (buffer-name)))
        (string-prefix-p (denote-directory) (expand-file-name default-directory))))
 
-;;;; Keywords
-
 (defun denote--directory-files-recursively (directory)
   "Return expanded files in DIRECTORY recursively."
   (mapcar
@@ -465,6 +463,8 @@ names that are relative to the variable `denote-directory'."
                  (not (string= (file-name-nondirectory (buffer-file-name)) f)))
         f))
     (denote--directory-files))))
+
+;;;; Keywords
 
 (defun denote--extract-keywords-from-path (path)
   "Extract keywords from PATH."

--- a/denote.el
+++ b/denote.el
@@ -781,8 +781,6 @@ When called from Lisp, all arguments are optional.
     (denote--prepare-note (or title "") keywords date id directory file-type)
     (denote--keywords-add-to-history keywords)))
 
-(defalias 'denote-create-note (symbol-function 'denote))
-
 ;;;;; The `denote-type' command
 
 (defvar denote--file-type-history nil
@@ -805,19 +803,6 @@ here for clarity."
    ((symbolp filetype)
     filetype)
    (t (user-error "`%s' is not a symbol or string" filetype))))
-
-;;;###autoload
-(defun denote-type ()
-  "Create note while prompting for a file type.
-
-This is the equivalent to calling `denote' when `denote-prompts'
-is set to \\='(file-type title keywords)."
-  (declare (interactive-only t))
-  (interactive)
-  (let ((denote-prompts '(file-type title keywords)))
-    (call-interactively #'denote)))
-
-(defalias 'denote-create-note-using-type (symbol-function 'denote-type))
 
 ;;;;; The `denote-date' command
 
@@ -883,22 +868,6 @@ where the former does not read dates without a time component."
       (user-error "`%s' already exists; aborting new note creation" identifier)
     t))
 
-;;;###autoload
-(defun denote-date ()
-  "Create note while prompting for a date.
-
-The date can be in YEAR-MONTH-DAY notation like 2022-06-30 or
-that plus the time: 2022-06-16 14:30
-
-This is the equivalent to calling `denote' when `denote-prompts'
-is set to \\='(date title keywords)."
-  (declare (interactive-only t))
-  (interactive)
-  (let ((denote-prompts '(date title keywords)))
-    (call-interactively #'denote)))
-
-(defalias 'denote-create-note-using-date (symbol-function 'denote-date))
-
 ;;;;; The `denote-subdirectory' command
 
 (defvar denote--subdir-history nil
@@ -932,6 +901,39 @@ is set to \\='(date title keywords)."
          (subdirs (denote--subdirs))
          (dirs (push root subdirs)))
     (denote--subdirs-completion-table dirs)))
+
+;;;;; Convenience functions
+
+(defalias 'denote-create-note (symbol-function 'denote))
+
+;;;###autoload
+(defun denote-type ()
+  "Create note while prompting for a file type.
+
+This is the equivalent to calling `denote' when `denote-prompts'
+is set to \\='(file-type title keywords)."
+  (declare (interactive-only t))
+  (interactive)
+  (let ((denote-prompts '(file-type title keywords)))
+    (call-interactively #'denote)))
+
+(defalias 'denote-create-note-using-type (symbol-function 'denote-type))
+
+;;;###autoload
+(defun denote-date ()
+  "Create note while prompting for a date.
+
+The date can be in YEAR-MONTH-DAY notation like 2022-06-30 or
+that plus the time: 2022-06-16 14:30
+
+This is the equivalent to calling `denote' when `denote-prompts'
+is set to \\='(date title keywords)."
+  (declare (interactive-only t))
+  (interactive)
+  (let ((denote-prompts '(date title keywords)))
+    (call-interactively #'denote)))
+
+(defalias 'denote-create-note-using-date (symbol-function 'denote-date))
 
 ;;;###autoload
 (defun denote-subdirectory ()


### PR DESCRIPTION
Just a small cleanup of denote.el. There is no new code. You can look at the individual commits.

In summary:
- Put the convenience functions in their own sections.
- Rename the "denote command" to "denote command and its prompts" and move the helper functions out of it.