### PR TITLE
Move functions from denote-dired.el and create some utility functions

### DIFF
--- a/denote-retrieve.el
+++ b/denote-retrieve.el
@@ -45,10 +45,6 @@
   "^\\(?:#\\+\\)?\\(?:date\\)\\s-*[:=]"
   "Regular expression for date key.")
 
-(defconst denote-retrieve--keywords-front-matter-key-regexp
-  "^\\(?:#\\+\\)?\\(?:tags\\|filetags\\)\\s-*[:=]"
-  "Regular expression for keywords key.")
-
 (defun denote-retrieve--filename-identifier (file)
   "Extract identifier from FILE name."
   (if (file-exists-p file)


### PR DESCRIPTION
I have started some work following the discussion on the mailing list.

---

I moved some functions from `denote-dired.el` to `denote.el` for these reasons:

- Some are not related enough to Dired or specific to Dired.
- As a work-in-progress, it is not clear what we will end up with. We can split into more appropriate files later.

I have created a section for "Note modifications" in `denote.el` for these moved functions.

I have created 2 utility functions that will probably be useful soon:

- `denote--extract-keywords-from-front-matter`: The reverse of `denote--file-meta-keywords`.
- `denote--rename-file` that just renames the file without any prompts. Later, we can use it, for example, in functions like `denote-rename-file-using-front-matter`, `denote-rename-file-using-prompts` or `denote-rename-marked-files`.

So far, I have not made any user-visible changes. Let me know what you think of this direction.

---

I learned a few things about elisp when doing the previous modifications. I have noticed that I needed to call functions/variables in `denote-retrieve.el` from `denote.el`. However, in elisp, we cannot have cyclic dependencies. Since `denote-retrieve.el` needs to call `denote.el` and it would be natural to want to call `denote-retrieve.el` from `denote.el` as is the case in this refactor, I think it would be preferable to have it all directly in `denote.el` in its own section. It is also a short file of internal functions only. For now, I have just moved what I needed in `denote.el`, but it needs further refactor. What do you think of this?