### PR TITLE
Cleanup

### DIFF
--- a/denote.el
+++ b/denote.el
@@ -1900,6 +1900,7 @@ Use optional TITLE for a prettier heading."
   (let ((inhibit-read-only t)
         (buf (format "*denote-backlinks to %s*" id)))
     (with-current-buffer (get-buffer-create buf)
+      (setq-local default-directory (denote-directory))
       (erase-buffer)
       (special-mode)
       (goto-char (point-min))

--- a/denote.el
+++ b/denote.el
@@ -617,18 +617,14 @@ The xrefs are returned as an alist."
   "Return sorted file names sans directory from XREFS.
 Parse `denote--retrieve-xrefs'."
   (sort
-   (delete-dups
-    (mapcar (lambda (x)
-              (denote--file-name-relative-to-denote-directory (car x)))
-            xrefs))
+   (delete-dups (mapcar #'car xrefs))
    #'string-lessp))
 
 (defun denote--retrieve-proces-grep (identifier)
   "Process lines matching IDENTIFIER and return list of files."
-  (let ((file (denote--file-name-relative-to-denote-directory (buffer-file-name))))
-    (denote--retrieve-files-in-output
-     (delete file (denote--retrieve-files-in-xrefs
-                   (denote--retrieve-xrefs identifier))))))
+  (denote--retrieve-files-in-output
+   (delete (buffer-file-name) (denote--retrieve-files-in-xrefs
+                               (denote--retrieve-xrefs identifier)))))
 
 ;;;; New note
 
@@ -1912,7 +1908,7 @@ Use optional TITLE for a prettier heading."
                   (l (length heading)))
         (insert (format "%s\n%s\n\n" heading (make-string l ?-))))
       (mapc (lambda (f)
-              (insert f)
+              (insert (denote--file-name-relative-to-denote-directory f))
               (make-button (point-at-bol) (point-at-eol) :type 'denote-link-backlink-button)
               (newline))
             files)

--- a/denote.el
+++ b/denote.el
@@ -895,11 +895,10 @@ where the former does not read dates without a time component."
 ;; notes within fractions of a second).
 (defun denote--id-exists-p (identifier)
   "Return non-nil if IDENTIFIER already exists."
-  (or (seq-some (lambda (file)
-                  (string-match-p (concat "\\`" identifier) file))
-                (denote--buffer-file-names))
-      (denote--directory-files-matching-regexp
-       (concat "\\`" identifier))))
+  (seq-some (lambda (file)
+              (string-prefix-p identifier (file-name-nondirectory file)))
+            (concat (denote--directory-files :absolute)
+                    (denote--buffer-file-names))))
 
 (defun denote--barf-duplicate-id (identifier)
   "Throw a user-error if IDENTIFIER already exists."

--- a/denote.el
+++ b/denote.el
@@ -1961,9 +1961,6 @@ default, it will show up below the current window."
 
 ;;;;; Add links matching regexp
 
-(defvar denote-link--links-to-files nil
-  "String of `denote-link-add-links-matching-keyword'.")
-
 (defvar denote-link--prepare-links-format "- %s\n"
   "Format specifiers for `denote-link-add-links'.")
 
@@ -1976,18 +1973,17 @@ default, it will show up below the current window."
   "Prepare links to FILES from CURRENT-FILE.
 When ID-ONLY is non-nil, use a generic link format.  See
 `denote-link--file-type-format'."
-  (setq denote-link--links-to-files
-        (with-temp-buffer
-          (mapc (lambda (file)
-                  (insert
-                   (format
-                    denote-link--prepare-links-format
-                    (denote-link--format-link
-                     file
-                     (denote-link--file-type-format current-file id-only)))))
-                files)
-          (sort-lines denote-link-add-links-sort (point-min) (point-max))
-          (buffer-string))))
+  (with-temp-buffer
+    (mapc (lambda (file)
+            (insert
+             (format
+              denote-link--prepare-links-format
+              (denote-link--format-link
+               file
+               (denote-link--file-type-format current-file id-only)))))
+          files)
+    (sort-lines denote-link-add-links-sort (point-min) (point-max))
+    (buffer-string)))
 
 (defvar denote-link--add-links-history nil
   "Minibuffer history for `denote-link-add-links'.")

--- a/denote.el
+++ b/denote.el
@@ -895,13 +895,9 @@ where the former does not read dates without a time component."
   "Return list of subdirectories in variable `denote-directory'."
   (seq-remove
    (lambda (filename)
-     ;; TODO 2022-07-03: Generalise for all VC backends.  Which ones?
-     ;;
-     ;; TODO 2022-07-03: Maybe it makes sense to also allow the user to
-     ;; specify a blocklist of directories that should always be
-     ;; excluded?
-     (or (string-match-p "\\.git" filename)
-         (not (file-directory-p filename))))
+     (or (not (file-directory-p filename))
+         (string-match-p "\\`\\." (denote--file-name-relative-to-denote-directory filename))
+         (string-match-p "/\\." (denote--file-name-relative-to-denote-directory filename))))
    (directory-files-recursively (denote-directory) ".*" t t)))
 
 ;;;;; The `denote' command and its prompts

--- a/denote.el
+++ b/denote.el
@@ -467,8 +467,7 @@ FILE must be an absolute path."
   "List note files.
 If optional ABSOLUTE, show full paths, else only show base file
 names that are relative to the variable `denote-directory'."
-  (let* ((default-directory (denote-directory))
-         (files (denote--directory-files-recursively default-directory)))
+  (let ((files (denote--directory-files-recursively (denote-directory))))
     (if absolute
         files
       (mapcar
@@ -636,8 +635,7 @@ Parse `denote--retrieve-xrefs'."
 
 (defun denote--retrieve-proces-grep (identifier)
   "Process lines matching IDENTIFIER and return list of files."
-  (let* ((default-directory (denote-directory))
-         (file (denote--file-name-relative-to-denote-directory (buffer-file-name))))
+  (let ((file (denote--file-name-relative-to-denote-directory (buffer-file-name))))
     (denote--retrieve-files-in-output
      (delete file (denote--retrieve-files-in-xrefs
                    (denote--retrieve-xrefs identifier))))))
@@ -831,9 +829,8 @@ With optional DATE, use it else use the current one."
 
 Arguments TITLE, KEYWORDS, DATE, ID, DIRECTORY, FILE-TYPE,
 and TEMPLATE should be valid for note creation."
-  (let* ((default-directory directory)
-         (denote-file-type file-type)
-         (path (denote--path title keywords default-directory id))
+  (let* ((denote-file-type file-type)
+         (path (denote--path title keywords directory id))
          (buffer (find-file path))
          (header (denote--format-front-matter
                   title (denote--date date) keywords
@@ -1200,7 +1197,7 @@ variable `denote-directory'."
          (not (denote--file-empty-p file))
          (string-match-p "\\(md\\|org\\|txt\\)\\'" ext)
          ;; Heuristic to check if this is one of our notes
-         (string-prefix-p (denote-directory) (expand-file-name default-directory))
+         (string-prefix-p (denote-directory) (expand-file-name file))
          (denote--file-match-p denote--retrieve-title-front-matter-key-regexp file)
          (denote--file-match-p denote--retrieve-keywords-front-matter-key-regexp file))))
 
@@ -1953,8 +1950,7 @@ The placement of the backlinks' buffer is controlled by the user
 option `denote-link-backlinks-display-buffer-action'.  By
 default, it will show up below the current window."
   (interactive)
-  (let* ((default-directory (denote-directory))
-         (file (buffer-file-name))
+  (let* ((file (buffer-file-name))
          (id (denote--retrieve-filename-identifier file))
          (title (denote--retrieve-value-title file)))
     (if-let ((files (denote--retrieve-proces-grep id)))
@@ -2009,8 +2005,7 @@ inserts links with just the identifier."
    (list
     (read-regexp "Insert links matching REGEX: " nil 'denote-link--add-links-history)
     current-prefix-arg))
-  (let* ((default-directory (denote-directory))
-         (current-file (buffer-file-name)))
+  (let ((current-file (buffer-file-name)))
     (if-let ((files (denote--directory-files-matching-regexp regexp)))
         (let ((beg (point)))
           (insert (denote-link--prepare-links files current-file id-only))

--- a/denote.el
+++ b/denote.el
@@ -482,13 +482,14 @@ names that are relative to the variable `denote-directory'."
    (denote--directory-files :absolute)))
 
 (defun denote--directory-files-matching-regexp (regexp)
-  "Return list of files matching REGEXP."
+  "Return list of files matching REGEXP.
+The match is performed against the file name relative to the
+variable `denote-directory'."
   (seq-filter
    (lambda (f)
      (and (denote--only-note-p f)
-          (string-match-p regexp f)
-          (not (string= (file-name-nondirectory (buffer-file-name)) f))))
-   (denote--directory-files)))
+          (string-match-p regexp (denote--file-name-relative-to-denote-directory f))))
+   (denote--directory-files :absolute)))
 
 ;;;; Keywords
 

--- a/denote.el
+++ b/denote.el
@@ -894,14 +894,11 @@ where the former does not read dates without a time component."
 ;; notes within fractions of a second).
 (defun denote--id-exists-p (identifier)
   "Return non-nil if IDENTIFIER already exists."
-  (let ((current-buffer-name (when (buffer-file-name)
-                               (file-name-nondirectory (buffer-file-name)))))
-    (or (seq-some (lambda (file)
-                    (string-match-p (concat "\\`" identifier) file))
-                  (delete current-buffer-name (denote--buffer-file-names)))
-        (delete current-buffer-name
-                (denote--directory-files-matching-regexp
-                 (concat "\\`" identifier))))))
+  (or (seq-some (lambda (file)
+                  (string-match-p (concat "\\`" identifier) file))
+                (denote--buffer-file-names))
+      (denote--directory-files-matching-regexp
+       (concat "\\`" identifier))))
 
 (defun denote--barf-duplicate-id (identifier)
   "Throw a user-error if IDENTIFIER already exists."
@@ -2002,7 +1999,7 @@ inserts links with just the identifier."
     (read-regexp "Insert links matching REGEX: " nil 'denote-link--add-links-history)
     current-prefix-arg))
   (let ((current-file (buffer-file-name)))
-    (if-let ((files (denote--directory-files-matching-regexp regexp)))
+    (if-let ((files (delete current-file (denote--directory-files-matching-regexp regexp))))
         (let ((beg (point)))
           (insert (denote-link--prepare-links files current-file id-only))
           (unless (derived-mode-p 'org-mode)


### PR DESCRIPTION
Many cleanups:

- I have removed the let-bindings of `default-directory`. I had to be careful because let-binding `default-directory` can have non obvious consequences. Please double-check the code and test the affected functions: `denote`, `denote-link-backlinks`, `denote--edit-front-matter-p` (the renaming functions) and `denote-link-add-links`. My own tests did not yield any errors.

- I deleted the unused variable `denote-link--links-to-files`.

- I removed the check for the current-buffer in `denote--id-exists-p`. We already discussed this in another issue/pull request. We did not know what it was used for, but we kept it. `denote--id-exists-p` is only used by the `denote` command now. I don't know if it was used elsewhere previously, but I cannot imagine why this check would be necessary now. I say we remove it and if there is any issue, we fix it and document it. By the way, `denote--id-exists-p` has been broken for weeks (I fixed it. See below.).

- The following functions were simplified:
  - `denote--directory-files`: Remove the `absolute` argument from `denote--directory-files` because we (almost) always set it anyway.
  - `denote--directory-files-recursively`: Merged it in `denote--directory-files` because it is now only a single line.
  - `denote--buffer-file-names`: Now returns absolute paths as well.
  - `denote--retrieve-files-in-xrefs` and `denote--retrieve-proces-grep`: Use absolute paths.
  
  The idea is to keep these functions simple and make them always return absolute paths. We can use `denote--file-name-relative-to-denote-directory` on the items of the list, when necessary, but it does not happen often (only once for each function).

- In `denote-subdirs`, I removed the TODO items. I made it to ignore hidden directories. This way, a lot of VC backends are handled and we provide a way for users to create directories ignored by Denote in `denote-subdirectory`. What do you think of this?

Bugs that were noticed and fixed as part of these changes:

- Calling `(denote--id-regexp "some-existing-id")` at the root of `denote-directory` triggers the debugger. This has probably gone unnoticed because it is only used to check collisions and it never happens.

- In a note at the root of `denote-directory`, calling `denote-link-add-links` with a regex matching the current file does not add the current file to the links. Doing the same operation in a file inside a subdirectory adds the current file to the links.

- A directory called `some.notes.about.git` is ignored by Denote because it contains `.git`.