### PR TITLE
denote--format-front-matter: Handle nil filetype gracefuly

### DIFF
--- a/denote.el
+++ b/denote.el
@@ -764,8 +764,8 @@ provided by `denote'.  FILETYPE is one of the values of
       ('text (format denote-text-front-matter title date
                      (denote--format-front-matter-keywords keywords 'text)
                      id denote-text-front-matter-delimiter))
-      ('org (format denote-org-front-matter title date
-                    (denote--format-front-matter-keywords keywords 'org) id)))))
+      (_ (format denote-org-front-matter title date
+                 (denote--format-front-matter-keywords keywords 'org) id)))))
 
 (defun denote--path (title keywords dir id file-type)
   "Return path to new file with ID, TITLE, KEYWORDS and FILE-TYPE in DIR."


### PR DESCRIPTION
As descriped in denote-file-type docstring:

By default (a nil value), the file type is that of Org mode.
Any other non-nil value is the same as the default."