### PR TITLE
Cleanup

### DIFF
--- a/denote.el
+++ b/denote.el
@@ -654,7 +654,7 @@ Parse `denote--retrieve-xrefs'."
     ('markdown-toml ".md")
     ('markdown-yaml ".md")
     ('text ".txt")
-    (_ ".org")))
+    ('org ".org")))
 
 (defun denote--format-file (path id keywords title-slug extension)
   "Format file name.

--- a/denote.el
+++ b/denote.el
@@ -764,7 +764,7 @@ provided by `denote'.  FILETYPE is one of the values of
       ('text (format denote-text-front-matter title date
                      (denote--format-front-matter-keywords keywords 'text)
                      id denote-text-front-matter-delimiter))
-      (_ (format denote-org-front-matter title date
+      ('org (format denote-org-front-matter title date
                  (denote--format-front-matter-keywords keywords 'org) id)))))
 
 (defun denote--path (title keywords dir id file-type)
@@ -827,14 +827,15 @@ and TEMPLATE should be valid for note creation."
                               (expand-file-name directory)))
     directory))
 
-(defun denote--file-type-symbol (filetype)
-  "Return FILETYPE as a symbol."
-  (cond
-   ((stringp filetype)
-    (intern filetype))
-   ((symbolp filetype)
-    filetype)
-   (t (user-error "`%s' is not a symbol or string" filetype))))
+(defun denote--valid-file-type (filetype)
+  "Return a valid filetype given the argument FILETYPE."
+  (unless (or (symbolp filetype) (stringp filetype))
+    (user-error "`%s' is not a symbol or string" filetype))
+  (when (stringp filetype)
+    (setq filetype (intern filetype)))
+  (if (memq filetype '(text org markdown-toml markdown-yaml))
+      filetype
+    'org))
 
 (defun denote--date-add-current-time (date)
   "Add current time to DATE, if necessary.
@@ -934,7 +935,7 @@ When called from Lisp, all arguments are optional.
          ('template (aset args 5 (denote--template-prompt)))))
      (append args nil)))
   (let* ((title (or title ""))
-         (file-type (denote--file-type-symbol (or file-type denote-file-type)))
+         (file-type (denote--valid-file-type (or file-type denote-file-type)))
          (date (if (or (null date) (string-empty-p date))
                    (current-time)
                  (denote--valid-date date)))

--- a/denote.el
+++ b/denote.el
@@ -818,7 +818,7 @@ and TEMPLATE should be valid for note creation."
                   file-type)))
     (with-current-buffer buffer
       (insert header)
-      (when template (insert template)))))
+      (insert template))))
 
 (defun denote--dir-in-denote-directory-p (directory)
   "Return DIRECTORY if in variable `denote-directory', else nil."
@@ -933,7 +933,8 @@ When called from Lisp, all arguments are optional.
          ('date (aset args 4 (denote--date-prompt)))
          ('template (aset args 5 (denote--template-prompt)))))
      (append args nil)))
-  (let* ((file-type (denote--file-type-symbol (or file-type denote-file-type)))
+  (let* ((title (or title ""))
+         (file-type (denote--file-type-symbol (or file-type denote-file-type)))
          (date (if (or (null date) (string-empty-p date))
                    (current-time)
                  (denote--valid-date date)))
@@ -941,9 +942,11 @@ When called from Lisp, all arguments are optional.
          (directory (if (denote--dir-in-denote-directory-p subdirectory)
                         (file-name-as-directory subdirectory)
                       (denote-directory)))
-         (template (if (stringp template) template (alist-get template denote-templates))))
+         (template (if (stringp template)
+                       template
+                     (or (alist-get template denote-templates) ""))))
     (denote--barf-duplicate-id id)
-    (denote--prepare-note (or title "") keywords date id directory file-type template)
+    (denote--prepare-note title keywords date id directory file-type template)
     (denote--keywords-add-to-history keywords)))
 
 (defvar denote--title-history nil

--- a/denote.el
+++ b/denote.el
@@ -660,17 +660,14 @@ Parse `denote--retrieve-xrefs'."
   "Format file name.
 PATH, ID, KEYWORDS, TITLE-SLUG are expected to be supplied by
 `denote' or equivalent: they will all be converted into a single
-string.  EXTENSION is the file type extension, either a string
-which include the starting dot or the return value of
-`denote--file-extension'."
+string.  EXTENSION is the file type extension, as a string."
   (let ((kws (denote--keywords-combine keywords))
-        (ext (or extension (denote--file-extension denote-file-type)))
         (file-name (concat path id)))
     (when (and title-slug (not (string-empty-p title-slug)))
       (setq file-name (concat file-name "--" title-slug)))
     (when keywords
       (setq file-name (concat file-name "__" kws)))
-    (concat file-name ext)))
+    (concat file-name extension)))
 
 (defun denote--format-front-matter-keywords (keywords type)
   "Format KEYWORDS according to TYPE for the file's front matter.


### PR DESCRIPTION
I have made the change discussed in #84.

It includes these changes:
- In `denote` command, make sure `denote--prepare-notes` is called with valid values.
- Rename the function `denote--file-type-symbol` to `denote--valid-file-type` to make it return a valid file-type.
- Simplify `denote--format-file`. We always supply a non-nil extension parameter, so I removed the fallback on `denote--file-extension denote-file-type`.

The general theme of the cleanups of the previous days is to have simpler internal functions that minimize the use of fallback conditions, optional parameters and parameter validations. I think it makes it simpler for us. We can always expect the parameters of internal functions to be in a valid state.

The changes above do not require a new version.