### PR TITLE
File types section

### DIFF
--- a/denote.el
+++ b/denote.el
@@ -642,7 +642,7 @@ identifier: %s
   "Extract keywords list from front matter KEYWORDS-STRING."
   (split-string keywords-string "[:,\s]+" t "[][ \"']+"))
 
-(defvar denote--file-types
+(defvar denote-file-types
   ;; If denote-file-type is nil, we use the first element
   ;; of denote-file-types for new note creation, which we want
   ;; to be org by default.
@@ -709,39 +709,39 @@ TYPE-INFO is a list of 8 elements:
 
 (defun denote--file-extension (file-type)
   "Return file type extension based on FILE-TYPE."
-  (nth 0 (alist-get file-type denote--file-types)))
+  (nth 0 (alist-get file-type denote-file-types)))
 
 (defun denote--front-matter (file-type)
   "Return front matter based on FILE-TYPE."
-  (nth 1 (alist-get file-type denote--file-types)))
+  (nth 1 (alist-get file-type denote-file-types)))
 
 (defun denote--title-key-regexp (file-type)
   "Return the title key regexp associated to FILE-TYPE."
-  (nth 2 (alist-get file-type denote--file-types)))
+  (nth 2 (alist-get file-type denote-file-types)))
 
 (defun denote--title-value-function (file-type)
   "Function to convert the title string to a front matter title.
 Based on FILE-TYPE."
-  (nth 3 (alist-get file-type denote--file-types)))
+  (nth 3 (alist-get file-type denote-file-types)))
 
 (defun denote--title-value-reverse-function (file-type)
   "Function to convert a front matter title to the title string.
 Based on FILE-TYPE."
-  (nth 4 (alist-get file-type denote--file-types)))
+  (nth 4 (alist-get file-type denote-file-types)))
 
 (defun denote--keywords-key-regexp (file-type)
   "Return the keywords key regexp associated to FILE-TYPE."
-  (nth 5 (alist-get file-type denote--file-types)))
+  (nth 5 (alist-get file-type denote-file-types)))
 
 (defun denote--keywords-value-function (file-type)
   "Function to convert the keywords string to a front matter keywords.
 Based on FILE-TYPE."
-  (nth 6 (alist-get file-type denote--file-types)))
+  (nth 6 (alist-get file-type denote-file-types)))
 
 (defun denote--keywords-value-reverse-function (file-type)
   "Function to convert a front matter keywords to the keywords list.
 Based on FILE-TYPE."
-  (nth 7 (alist-get file-type denote--file-types)))
+  (nth 7 (alist-get file-type denote-file-types)))
 
 (defun denote--get-title-line-from-front-matter (file-type)
   "Retrieve title line from front matter based on FILE-TYPE.
@@ -951,15 +951,15 @@ and TEMPLATE should be valid for note creation."
 
 (defun denote--valid-file-type (filetype)
   "Return a valid filetype given the argument FILETYPE.
-If none is found, the first element of `denote--file-types' is
+If none is found, the first element of `denote-file-types' is
 returned."
   (unless (or (symbolp filetype) (stringp filetype))
     (user-error "`%s' is not a symbol or string" filetype))
   (when (stringp filetype)
     (setq filetype (intern filetype)))
-  (if (memq filetype (mapcar 'car denote--file-types))
+  (if (memq filetype (mapcar 'car denote-file-types))
       filetype
-    (caar denote--file-types)))
+    (caar denote-file-types)))
 
 (defun denote--date-add-current-time (date)
   "Add current time to DATE, if necessary.
@@ -1217,12 +1217,12 @@ If more than one file type correspond to this file extension,
 use the first file type for which the key-title-kegexp matches
 in the file.
 Else, if nothing works, the file type is assumed to be the first
-in `denote--file-types'."
+in `denote-file-types'."
   (let* ((file-type)
          (extension (file-name-extension file t))
          (types (seq-filter (lambda (type)
                               (string-equal (nth 1 type) extension))
-                            denote--file-types)))
+                            denote-file-types)))
     (if (= (length types) 1)
         (setq file-type types)
       (setq file-type (seq-find
@@ -1230,7 +1230,7 @@ in `denote--file-types'."
                          (denote--regexp-in-file-p (nth 3 type) file))
                        types)))
     (unless file-type
-      (caar denote--file-types))))
+      (caar denote-file-types))))
 
 (defun denote--file-attributes-time (file)
   "Return `file-attribute-modification-time' of FILE as identifier."

--- a/denote.el
+++ b/denote.el
@@ -878,13 +878,6 @@ Apply `downcase' to KEYWORDS."
   (let ((kw (mapcar #'downcase (denote--sluggify-keywords keywords))))
     (funcall (denote--keywords-value-function file-type) kw)))
 
-(defun denote--front-matter-keywords-to-list (file file-type)
-  "Return keywords from front matter of FILE as list of strings.
-FILE-TYPE is used to retrieve the keywords. This is the reverse
-operation of `denote--format-front-matter-keywords'."
-  (when-let ((keywords (denote--retrieve-value-keywords file file-type)))
-    (split-string keywords "[:,\s]+" t "[][ \"']+")))
-
 (make-obsolete-variable 'denote-text-front-matter-delimiter nil "0.6.0")
 
 (defun denote--format-front-matter (title date keywords id filetype)
@@ -1565,7 +1558,7 @@ typos and the like."
     (user-error "Save buffer before proceeding"))
   (if-let* ((file-type (denote--filetype-heuristics file))
             (title (denote--retrieve-value-title file file-type))
-            (keywords (denote--front-matter-keywords-to-list file file-type))
+            (keywords (denote--retrieve-value-keywords file file-type))
             (extension (file-name-extension file t))
             (id (denote--file-name-id file))
             (dir (file-name-directory file))
@@ -1617,7 +1610,7 @@ their respective front matter."
                  (id (denote--file-name-id file))
                  (file-type (denote--filetype-heuristics file))
                  (title (denote--retrieve-value-title file file-type))
-                 (keywords (denote--front-matter-keywords-to-list file file-type))
+                 (keywords (denote--retrieve-value-keywords file file-type))
                  (extension (file-name-extension file t))
                  (new-name (denote--format-file
                             dir id keywords (denote--sluggify title) extension)))
@@ -2428,7 +2421,7 @@ of Denote.  Written on 2022-08-10 for version 0.5.0."
   (when-let (((yes-or-no-p "Rewrite filetags in Org files to use colons (buffers are NOT saved)?"))
              (files (denote--migrate-type-files "org" 'org)))
     (dolist (file files)
-      (when-let* ((kw (denote--front-matter-keywords-to-list file 'org))
+      (when-let* ((kw (denote--retrieve-value-keywords file 'org))
                   ((denote--edit-front-matter-p file 'org)))
         (denote--rewrite-keywords file kw 'org)))))
 
@@ -2459,7 +2452,7 @@ of Denote.  Written on 2022-08-10 for version 0.5.0."
   (when-let (((yes-or-no-p "Rewrite tags in Markdown files with YAML header to use lists (buffers are NOT saved)?"))
              (files (denote--migrate-type-files "md" 'markdown-yaml)))
     (dolist (file files)
-      (when-let* ((kw (denote--front-matter-keywords-to-list file 'markdown-yaml))
+      (when-let* ((kw (denote--retrieve-value-keywords file 'markdown-yaml))
                   ((denote--edit-front-matter-p file 'markdown-yaml)))
         (denote--rewrite-keywords file kw 'markdown-yaml)))))
 

--- a/denote.el
+++ b/denote.el
@@ -886,7 +886,8 @@ Apply `downcase' to KEYWORDS."
 TITLE, DATE, KEYWORDS, FILENAME, ID are all strings which are
 provided by `denote'.  FILETYPE is one of the values of
 `denote-file-type'."
-  (let ((kws (denote--format-front-matter-keywords keywords filetype)))
+  (let ((title (denote--format-front-matter-title title filetype))
+        (kws (denote--format-front-matter-keywords keywords filetype)))
     (format (denote--front-matter filetype) title date kws id)))
 
 (defun denote--path (title keywords dir id file-type)

--- a/denote.el
+++ b/denote.el
@@ -638,6 +638,68 @@ identifier: %s
   "Extract keywords list from front matter KEYWORDS-STRING."
   (split-string keywords-string "[:,\s]+" t "[][ \"']+"))
 
+(defvar denote--file-types
+  `((markdown-toml . (".md"
+                      ,denote--toml-front-matter
+                      "^title\\s-*="
+                      denote--surround-with-quotes
+                      denote--trim-whitespace-then-quotes
+                      "^tags\\s-*="
+                      denote--format-keywords-for-md-front-matter
+                      denote--extract-keywords-from-front-matter))
+    (markdown-yaml . (".md"
+                      ,denote--yaml-front-matter
+                      "^title\\s-*:"
+                      denote--surround-with-quotes
+                      denote--trim-whitespace-then-quotes
+                      "^tags\\s-*:"
+                      denote--format-keywords-for-md-front-matter
+                      denote--extract-keywords-from-front-matter))
+    (text . (".txt"
+             ,denote--yaml-front-matter
+             "^title\\s-*:"
+             identity
+             denote--trim-whitespace
+             "^tags\\s-*:"
+             denote--format-keywords-for-text-front-matter
+             denote--extract-keywords-from-front-matter))
+    (org . (".org"
+            ,denote--org-front-matter
+            "^#\\+title\\s-*:"
+            identity
+            denote--trim-whitespace
+            "^#\\+tags\\s-*:"
+            denote--format-keywords-for-text-front-matter
+            denote--extract-keywords-from-front-matter)))
+  "Alist for Denote's file types.
+Each element is of the form (TYPE-SYMB . TYPE-INFO).
+
+TYPE-INFO is a list of 8 elements:
+
+  extension: The file extension, as a string.
+
+  front-matter: The type's front matter, as a string.
+
+  title-key-regexp: The regexp used to retrieve the title line in
+    a file. The first line matching this regexp is considered the
+    title line.
+
+  title-value-function: The function used to format the raw title
+    string for inclusion in the front matter.
+
+  title-value-reverse-function: The function used to retrieve the raw title
+    string from the string in the front matter.
+
+  keywords-key-regexp: The regexp used to retrieve the keywords
+    line in a file. The first line matching this regexp is
+    considered the keywords line.
+
+  keywords-value-function: The function used to format the
+    keywords list for inclusion in the front matter.
+
+  keywords-value-reverse-function: The function used to retrieve
+    the keywords list from the string in the front matter.")
+
 (defun denote--file-extension (file-type)
   "Return file type extension based on FILE-TYPE."
   (pcase file-type

--- a/denote.el
+++ b/denote.el
@@ -775,7 +775,7 @@ Does not contain the newline."
         (match-string 0 file))
     (error "Cannot find `%s' as a file" file)))
 
-(defun denote--retrieve-value-title (file file-type)
+(defun denote--retrieve-title-value (file file-type)
   "Return title value from FILE according to FILE-TYPE."
   (when (or (denote--writable-and-supported-p file)
             (denote--only-note-p file))
@@ -795,7 +795,7 @@ Does not contain the newline."
       (when (re-search-forward (denote--title-key-regexp file-type) nil t 1)
         (buffer-substring-no-properties (point-at-bol) (point-at-eol))))))
 
-(defun denote--retrieve-value-keywords (file file-type)
+(defun denote--retrieve-keywords-value (file file-type)
   "Return keywords value from FILE according to FILE-TYPE.
 If optional KEY is non-nil, return the key instead."
   (when (or (denote--writable-and-supported-p file)
@@ -1329,7 +1329,7 @@ operation on multiple files."
           (delete-region (point) (point-at-eol)))))))
 
 ;; FIXME 2022-07-25: We should make the underlying regular expressions
-;; that `denote--retrieve-value-title' targets more refined, so that we
+;; that `denote--retrieve-title-value' targets more refined, so that we
 ;; capture eveyrhing at once.
 (defun denote--rewrite-front-matter (file title keywords file-type)
   "Rewrite front matter of note after `denote-dired-rename-file'.
@@ -1452,7 +1452,7 @@ files)."
      (list
       file
       (denote--title-prompt
-       (or (denote--retrieve-value-title file file-type) (file-name-base file)))
+       (or (denote--retrieve-title-value file file-type) (file-name-base file)))
       (denote--keywords-prompt))))
   (let* ((dir (file-name-directory file))
          (id (denote--file-name-id file))
@@ -1520,7 +1520,7 @@ The operation does the following:
           (let* ((dir (file-name-directory file))
                  (id (denote--file-name-id file))
                  (file-type (denote--filetype-heuristics file))
-                 (title (or (denote--retrieve-value-title file file-type)
+                 (title (or (denote--retrieve-title-value file file-type)
                             (file-name-base file)))
                  (extension (file-name-extension file t))
                  (new-name (denote--format-file
@@ -1557,8 +1557,8 @@ typos and the like."
   (when (buffer-modified-p)
     (user-error "Save buffer before proceeding"))
   (if-let* ((file-type (denote--filetype-heuristics file))
-            (title (denote--retrieve-value-title file file-type))
-            (keywords (denote--retrieve-value-keywords file file-type))
+            (title (denote--retrieve-title-value file file-type))
+            (keywords (denote--retrieve-keywords-value file file-type))
             (extension (file-name-extension file t))
             (id (denote--file-name-id file))
             (dir (file-name-directory file))
@@ -1609,8 +1609,8 @@ their respective front matter."
           (let* ((dir (file-name-directory file))
                  (id (denote--file-name-id file))
                  (file-type (denote--filetype-heuristics file))
-                 (title (denote--retrieve-value-title file file-type))
-                 (keywords (denote--retrieve-value-keywords file file-type))
+                 (title (denote--retrieve-title-value file file-type))
+                 (keywords (denote--retrieve-keywords-value file file-type))
                  (extension (file-name-extension file t))
                  (new-name (denote--format-file
                             dir id keywords (denote--sluggify title) extension)))
@@ -1895,7 +1895,7 @@ title."
       (let* ((file-id (denote--retrieve-filename-identifier file))
              (file-type (denote--filetype-heuristics file))
              (file-title (unless (string= pattern denote-link--format-id-only)
-                           (denote--retrieve-value-title file file-type))))
+                           (denote--retrieve-title-value file file-type))))
         (format pattern file-id file-title))
     (format denote-link--format-id-only
             (denote--retrieve-filename-identifier file))))
@@ -2106,7 +2106,7 @@ default, it will show up below the current window."
   (let* ((file (buffer-file-name))
          (id (denote--retrieve-filename-identifier file))
          (file-type (denote--filetype-heuristics file))
-         (title (denote--retrieve-value-title file file-type)))
+         (title (denote--retrieve-title-value file file-type)))
     (if-let ((files (denote--retrieve-process-grep id)))
         (denote-link--prepare-backlinks id files title)
       (user-error "No links to the current note"))))
@@ -2421,7 +2421,7 @@ of Denote.  Written on 2022-08-10 for version 0.5.0."
   (when-let (((yes-or-no-p "Rewrite filetags in Org files to use colons (buffers are NOT saved)?"))
              (files (denote--migrate-type-files "org" 'org)))
     (dolist (file files)
-      (when-let* ((kw (denote--retrieve-value-keywords file 'org))
+      (when-let* ((kw (denote--retrieve-keywords-value file 'org))
                   ((denote--edit-front-matter-p file 'org)))
         (denote--rewrite-keywords file kw 'org)))))
 
@@ -2452,7 +2452,7 @@ of Denote.  Written on 2022-08-10 for version 0.5.0."
   (when-let (((yes-or-no-p "Rewrite tags in Markdown files with YAML header to use lists (buffers are NOT saved)?"))
              (files (denote--migrate-type-files "md" 'markdown-yaml)))
     (dolist (file files)
-      (when-let* ((kw (denote--retrieve-value-keywords file 'markdown-yaml))
+      (when-let* ((kw (denote--retrieve-keywords-value file 'markdown-yaml))
                   ((denote--edit-front-matter-p file 'markdown-yaml)))
         (denote--rewrite-keywords file kw 'markdown-yaml)))))
 

--- a/denote.el
+++ b/denote.el
@@ -743,10 +743,11 @@ Based on FILE-TYPE."
 Based on FILE-TYPE."
   (plist-get (alist-get file-type denote-file-types) :keywords-value-reverse-function))
 
-(defun denote--get-title-line-from-front-matter (file-type)
+(defun denote--get-title-line-from-front-matter (title file-type)
   "Retrieve title line from front matter based on FILE-TYPE.
-Does not contains the newline."
-  (let ((front-matter (denote--front-matter file-type))
+Format TITLE in the title line. The returned line does not
+contain the newline."
+  (let ((front-matter (denote--format-front-matter title "" nil "" file-type))
         (key-regexp (denote--title-key-regexp file-type)))
     (with-temp-buffer
       (insert front-matter)
@@ -754,10 +755,11 @@ Does not contains the newline."
       (when (re-search-forward key-regexp nil t 1)
         (buffer-substring-no-properties (point-at-bol) (point-at-eol))))))
 
-(defun denote--get-keywords-line-from-front-matter (file-type)
+(defun denote--get-keywords-line-from-front-matter (keywords file-type)
   "Retrieve keywords line from front matter based on FILE-TYPE.
-Does not contain the newline."
-  (let ((front-matter (denote--front-matter file-type))
+Format KEYWORDS in the keywords line. The returned line does not
+contain the newline."
+  (let ((front-matter (denote--format-front-matter "" "" keywords "" file-type))
         (key-regexp (denote--keywords-key-regexp file-type)))
     (with-temp-buffer
       (insert front-matter)
@@ -1325,8 +1327,7 @@ operation on multiple files."
         (goto-char (point-min))
         (when (re-search-forward (denote--keywords-key-regexp file-type) nil t 1)
           (goto-char (point-at-bol))
-          (insert (format (denote--get-keywords-line-from-front-matter file-type)
-                          (denote--format-front-matter-keywords keywords file-type)))
+          (insert (denote--get-keywords-line-from-front-matter keywords file-type))
           (delete-region (point) (point-at-eol)))))))
 
 ;; FIXME 2022-07-25: We should make the underlying regular expressions
@@ -1339,10 +1340,8 @@ renaming command and are used to construct new front matter
 values if appropriate."
   (when-let* ((old-title-line (denote--retrieve-title-line file file-type))
               (old-keywords-line (denote--retrieve-keywords-line file file-type))
-              (new-title-line (format (denote--get-title-line-from-front-matter file-type)
-                                      (denote--format-front-matter-title title file-type)))
-              (new-keywords-line (format (denote--get-keywords-line-from-front-matter file-type)
-                                         (denote--format-front-matter-keywords keywords file-type))))
+              (new-title-line (denote--get-title-line-from-front-matter title file-type))
+              (new-keywords-line (denote--get-keywords-line-from-front-matter keywords file-type)))
     (with-current-buffer (find-file-noselect file)
       (when (y-or-n-p (format
                        "Replace front matter?\n-%s\n+%s\n\n-%s\n+%s?"

--- a/denote.el
+++ b/denote.el
@@ -646,38 +646,38 @@ identifier: %s
   ;; If denote-file-type is nil, we use the first element
   ;; of denote-file-types for new note creation, which we want
   ;; to be org by default.
-  `((org . (".org"
-            ,denote-org-front-matter
-            "^#\\+title\\s-*:"
-            identity
-            denote--trim-whitespace
-            "^#\\+filetags\\s-*:"
-            denote--format-keywords-for-org-front-matter
-            denote--extract-keywords-from-front-matter))
-    (markdown-toml . (".md"
-                      ,denote-toml-front-matter
-                      "^title\\s-*="
-                      denote--surround-with-quotes
-                      denote--trim-whitespace-then-quotes
-                      "^tags\\s-*="
-                      denote--format-keywords-for-md-front-matter
-                      denote--extract-keywords-from-front-matter))
-    (markdown-yaml . (".md"
-                      ,denote-yaml-front-matter
-                      "^title\\s-*:"
-                      denote--surround-with-quotes
-                      denote--trim-whitespace-then-quotes
-                      "^tags\\s-*:"
-                      denote--format-keywords-for-md-front-matter
-                      denote--extract-keywords-from-front-matter))
-    (text . (".txt"
-             ,denote-yaml-front-matter
-             "^title\\s-*:"
-             identity
-             denote--trim-whitespace
-             "^tags\\s-*:"
-             denote--format-keywords-for-text-front-matter
-             denote--extract-keywords-from-front-matter)))
+  `((org . (:extension ".org"
+            :front-matter ,denote-org-front-matter
+            :title-key-regexp "^#\\+title\\s-*:"
+            :title-value-function identity
+            :title-value-reverse-function denote--trim-whitespace
+            :keywords-key-regexp "^#\\+filetags\\s-*:"
+            :keywords-value-function denote--format-keywords-for-org-front-matter
+            :keywords-value-reverse-function denote--extract-keywords-from-front-matter))
+    (markdown-toml . (:extension ".md"
+                      :front-matter ,denote-toml-front-matter
+                      :title-key-regexp "^title\\s-*="
+                      :title-value-function denote--surround-with-quotes
+                      :title-value-reverse-function denote--trim-whitespace-then-quotes
+                      :keywords-key-regexp "^tags\\s-*="
+                      :keywords-value-function denote--format-keywords-for-md-front-matter
+                      :keywords-value-reverse-function denote--extract-keywords-from-front-matter))
+    (markdown-yaml . (:extension ".md"
+                      :front-matter ,denote-yaml-front-matter
+                      :title-key-regexp "^title\\s-*:"
+                      :title-value-function denote--surround-with-quotes
+                      :title-value-reverse-function denote--trim-whitespace-then-quotes
+                      :keywords-key-regexp "^tags\\s-*:"
+                      :keywords-value-function denote--format-keywords-for-md-front-matter
+                      :keywords-value-reverse-function denote--extract-keywords-from-front-matter))
+    (text . (:extension ".txt"
+             :front-matter ,denote-yaml-front-matter
+             :title-key-regexp "^title\\s-*:"
+             :title-value-function identity
+             :title-value-reverse-function denote--trim-whitespace
+             :keywords-key-regexp "^tags\\s-*:"
+             :keywords-value-function denote--format-keywords-for-text-front-matter
+             :keywords-value-reverse-function denote--extract-keywords-from-front-matter)))
   "Alist for Denote's file types.
 Each element is of the form (TYPE-SYMB . TYPE-INFO).
 
@@ -709,39 +709,39 @@ TYPE-INFO is a list of 8 elements:
 
 (defun denote--file-extension (file-type)
   "Return file type extension based on FILE-TYPE."
-  (nth 0 (alist-get file-type denote-file-types)))
+  (plist-get (alist-get file-type denote-file-types) :extension))
 
 (defun denote--front-matter (file-type)
   "Return front matter based on FILE-TYPE."
-  (nth 1 (alist-get file-type denote-file-types)))
+  (plist-get (alist-get file-type denote-file-types) :front-matter))
 
 (defun denote--title-key-regexp (file-type)
   "Return the title key regexp associated to FILE-TYPE."
-  (nth 2 (alist-get file-type denote-file-types)))
+  (plist-get (alist-get file-type denote-file-types) :title-key-regexp))
 
 (defun denote--title-value-function (file-type)
   "Function to convert the title string to a front matter title.
 Based on FILE-TYPE."
-  (nth 3 (alist-get file-type denote-file-types)))
+  (plist-get (alist-get file-type denote-file-types) :title-value-function))
 
 (defun denote--title-value-reverse-function (file-type)
   "Function to convert a front matter title to the title string.
 Based on FILE-TYPE."
-  (nth 4 (alist-get file-type denote-file-types)))
+  (plist-get (alist-get file-type denote-file-types) :title-value-reverse-function))
 
 (defun denote--keywords-key-regexp (file-type)
   "Return the keywords key regexp associated to FILE-TYPE."
-  (nth 5 (alist-get file-type denote-file-types)))
+  (plist-get (alist-get file-type denote-file-types) :keywords-key-regexp))
 
 (defun denote--keywords-value-function (file-type)
   "Function to convert the keywords string to a front matter keywords.
 Based on FILE-TYPE."
-  (nth 6 (alist-get file-type denote-file-types)))
+  (plist-get (alist-get file-type denote-file-types) :keywords-value-function))
 
 (defun denote--keywords-value-reverse-function (file-type)
   "Function to convert a front matter keywords to the keywords list.
 Based on FILE-TYPE."
-  (nth 7 (alist-get file-type denote-file-types)))
+  (plist-get (alist-get file-type denote-file-types) :keywords-value-reverse-function))
 
 (defun denote--get-title-line-from-front-matter (file-type)
   "Retrieve title line from front matter based on FILE-TYPE.
@@ -1221,13 +1221,13 @@ in `denote-file-types'."
   (let* ((file-type)
          (extension (file-name-extension file t))
          (types (seq-filter (lambda (type)
-                              (string-equal (nth 1 type) extension))
+                              (string-equal (plist-get (cdr type) :extension) extension))
                             denote-file-types)))
     (if (= (length types) 1)
         (setq file-type types)
       (setq file-type (seq-find
                        (lambda (type)
-                         (denote--regexp-in-file-p (nth 3 type) file))
+                         (denote--regexp-in-file-p (plist-get (cdr type) :title-key-regexp) file))
                        types)))
     (unless file-type
       (caar denote-file-types))))

--- a/denote.el
+++ b/denote.el
@@ -1223,6 +1223,13 @@ set to \\='(template title keywords)."
 
 ;;;;; Common helpers for note modifications
 
+(defun denote--file-types-with-extension (extension)
+  "Return only the entries of `denote-file-types' with EXTENSION.
+See the format of `denote-file-types'."
+  (seq-filter (lambda (type)
+                (string-equal (plist-get (cdr type) :extension) extension))
+              denote-file-types))
+
 (defun denote--filetype-heuristics (file)
   "Return likely file type of FILE.
 Use the file extension to detect the file type of the file.
@@ -1233,9 +1240,7 @@ Else, if nothing works, the file type is assumed to be the first
 in `denote-file-types'."
   (let* ((file-type)
          (extension (file-name-extension file t))
-         (types (seq-filter (lambda (type)
-                              (string-equal (plist-get (cdr type) :extension) extension))
-                            denote-file-types)))
+         (types (denote--file-types-with-extension extension)))
     (if (= (length types) 1)
         (setq file-type (caar types))
       (let ((found-type (seq-find

--- a/denote.el
+++ b/denote.el
@@ -1224,13 +1224,16 @@ in `denote-file-types'."
                               (string-equal (plist-get (cdr type) :extension) extension))
                             denote-file-types)))
     (if (= (length types) 1)
-        (setq file-type types)
-      (setq file-type (seq-find
-                       (lambda (type)
-                         (denote--regexp-in-file-p (plist-get (cdr type) :title-key-regexp) file))
-                       types)))
+        (setq file-type (caar types))
+      (let ((found-type (seq-find
+                         (lambda (type)
+                           (denote--regexp-in-file-p (plist-get (cdr type) :title-key-regexp) file))
+                         types)))
+        (when found-type
+          (setq file-type (car found-type)))))
     (unless file-type
-      (caar denote-file-types))))
+      (setq file-type (caar denote-file-types)))
+    file-type))
 
 (defun denote--file-attributes-time (file)
   "Return `file-attribute-modification-time' of FILE as identifier."

--- a/denote.el
+++ b/denote.el
@@ -1289,11 +1289,8 @@ block if appropriate."
   "Return t if REGEXP matches in the FILE."
   (with-temp-buffer
     (insert-file-contents file)
-    (save-excursion
-      (save-restriction
-        (widen)
-        (goto-char (point-min))
-        (re-search-forward regexp nil t 1)))))
+    (goto-char (point-min))
+    (re-search-forward regexp nil t 1)))
 
 (defun denote--edit-front-matter-p (file file-type)
   "Test if FILE should be subject to front matter rewrite.

--- a/denote.el
+++ b/denote.el
@@ -1243,12 +1243,11 @@ in `denote-file-types'."
          (types (denote--file-types-with-extension extension)))
     (if (= (length types) 1)
         (setq file-type (caar types))
-      (let ((found-type (seq-find
-                         (lambda (type)
-                           (denote--regexp-in-file-p (plist-get (cdr type) :title-key-regexp) file))
-                         types)))
-        (when found-type
-          (setq file-type (car found-type)))))
+      (when-let ((found-type (seq-find
+                              (lambda (type)
+                                (denote--regexp-in-file-p (plist-get (cdr type) :title-key-regexp) file))
+                              types)))
+        (setq file-type (car found-type))))
     (unless file-type
       (setq file-type (caar denote-file-types)))
     file-type))

--- a/denote.el
+++ b/denote.el
@@ -779,6 +779,8 @@ contain the newline."
 
 (defun denote--retrieve-title-value (file file-type)
   "Return title value from FILE according to FILE-TYPE."
+  ;; NOTE 2022-08-11: The `or' is superfluous, but I am keeping it as a
+  ;; reminder.  See TODO comment above `denote--only-note-p'
   (when (or (denote--writable-and-supported-p file)
             (denote--only-note-p file))
     (with-temp-buffer
@@ -790,7 +792,10 @@ contain the newline."
 
 (defun denote--retrieve-title-line (file file-type)
   "Return title line from FILE according to FILE-TYPE."
-  (when (denote--writable-and-supported-p file)
+  ;; NOTE 2022-08-11: The `or' is superfluous, but I am keeping it as a
+  ;; reminder.  See TODO comment above `denote--only-note-p'
+  (when (or (denote--writable-and-supported-p file)
+            (denote--only-note-p file))
     (with-temp-buffer
       (insert-file-contents file)
       (goto-char (point-min))
@@ -800,6 +805,8 @@ contain the newline."
 (defun denote--retrieve-keywords-value (file file-type)
   "Return keywords value from FILE according to FILE-TYPE.
 If optional KEY is non-nil, return the key instead."
+  ;; NOTE 2022-08-11: The `or' is superfluous, but I am keeping it as a
+  ;; reminder.  See TODO comment above `denote--only-note-p'
   (when (or (denote--writable-and-supported-p file)
             (denote--only-note-p file))
     (with-temp-buffer
@@ -811,7 +818,10 @@ If optional KEY is non-nil, return the key instead."
 
 (defun denote--retrieve-keywords-line (file file-type)
   "Return keywords line from FILE according to FILE-TYPE."
-  (when (denote--writable-and-supported-p file)
+  ;; NOTE 2022-08-11: The `or' is superfluous, but I am keeping it as a
+  ;; reminder.  See TODO comment above `denote--only-note-p'
+  (when (or (denote--writable-and-supported-p file)
+            (denote--only-note-p file))
     (with-temp-buffer
       (insert-file-contents file)
       (goto-char (point-min))

--- a/denote.el
+++ b/denote.el
@@ -702,71 +702,39 @@ TYPE-INFO is a list of 8 elements:
 
 (defun denote--file-extension (file-type)
   "Return file type extension based on FILE-TYPE."
-  (pcase file-type
-    ('markdown-toml ".md")
-    ('markdown-yaml ".md")
-    ('text ".txt")
-    ('org ".org")))
+  (nth 0 (alist-get file-type denote--file-types)))
 
 (defun denote--front-matter (file-type)
   "Return front matter based on FILE-TYPE."
-  (pcase file-type
-    ('markdown-toml denote--toml-front-matter)
-    ('markdown-yaml denote--yaml-front-matter)
-    ('text denote--text-front-matter)
-    ('org denote--org-front-matter)))
+  (nth 1 (alist-get file-type denote--file-types)))
 
 (defun denote--title-key-regexp (file-type)
   "Return the title key regexp associated to FILE-TYPE."
-  (pcase file-type
-    ('markdown-toml "^title\\s-*=")
-    ('markdown-yaml "^title\\s-*:")
-    ('text "^title\\s-*:")
-    ('org "^#\\+title\\s-*:")))
-
-(defun denote--keywords-key-regexp (file-type)
-  "Return the keywords key regexp associated to FILE-TYPE."
-  (pcase file-type
-    ('markdown-toml "^tags\\s-*=")
-    ('markdown-yaml "^tags\\s-*:")
-    ('text "^tags\\s-*:")
-    ('org "^#\\+filetags\\s-*:")))
+  (nth 2 (alist-get file-type denote--file-types)))
 
 (defun denote--title-value-function (file-type)
   "Function to convert the title string to a front matter title.
 Based on FILE-TYPE."
-  (pcase file-type
-    ('markdown-toml #'denote--surround-with-quotes)
-    ('markdown-yaml #'denote--surround-with-quotes)
-    ('text #'identity)
-    ('org #'identity)))
+  (nth 3 (alist-get file-type denote--file-types)))
 
 (defun denote--title-value-reverse-function (file-type)
   "Function to convert a front matter title to the title string.
 Based on FILE-TYPE."
-  (pcase file-type
-    ('markdown-toml #'denote--trim-whitespace-then-quotes)
-    ('markdown-yaml #'denote--trim-whitespace-then-quotes)
-    ('text #'denote--trim-whitespace)
-    ('org #'denote--trim-whitespace)))
+  (nth 4 (alist-get file-type denote--file-types)))
+
+(defun denote--keywords-key-regexp (file-type)
+  "Return the keywords key regexp associated to FILE-TYPE."
+  (nth 5 (alist-get file-type denote--file-types)))
 
 (defun denote--keywords-value-function (file-type)
   "Function to convert the keywords string to a front matter keywords.
 Based on FILE-TYPE."
-  (pcase file-type
-    ('markdown-toml #'denote--format-keywords-for-md-front-matter)
-    ('markdown-yaml #'denote--format-keywords-for-md-front-matter)
-    ('text #'denote--format-keywords-for-text-front-matter)
-    ('org #'denote--format-keywords-for-org-front-matter)))
+  (nth 6 (alist-get file-type denote--file-types)))
 
 (defun denote--keywords-value-reverse-function (file-type)
   "Function to convert a front matter keywords to the keywords list.
 Based on FILE-TYPE."
-  (pcase file-type
-    ('markdown-toml #'denote--extract-keywords-from-front-matter)
-    ('markdown-yaml #'denote--extract-keywords-from-front-matter)
-    ('text #'denote--extract-keywords-from-front-matter)
-    ('org #'denote--extract-keywords-from-front-matter)))
+  (nth 7 (alist-get file-type denote--file-types)))
 
 ;;;; Front matter or content retrieval functions
 

--- a/denote.el
+++ b/denote.el
@@ -2386,11 +2386,11 @@ FILE-TYPE is the symbol file-type."
   (delq nil
         (mapcar
          (lambda (file)
-           (when-let* ((value (denote--retrieve-value-keywords
+           (when-let* ((value (denote--retrieve-keywords-line
                                file file-type))
                        ((cond
                          ((eq file-type 'markdown-yaml) (not (string-match-p "," value)))
-                         ((eq file-type 'org) (not (string-match-p ":" value)))
+                         ((eq file-type 'org) (not (string-match-p " :" value)))
                          (t nil))))
              file))
          (seq-remove


### PR DESCRIPTION
This is a proof-of-concept. I have some doubts, but I am sharing it with you.

I added a new section "File types" in the code. You can check the new **internal** variable `denote--file-types` and its docstring and other related functions.

It would still need refinements to be merged. We could then refactor many functions in denote.el to use the content of `denote--file-types`.

I copy here what I originally wrote for that pull request:

---

With `denote--file-types`, I did not consider user-friendliness. I just consolidated the various information we have about file types, without losing any of our existing functionalities. I suggest we first use `denote--file-types` internally for a while just to test how we like it and to allow us to make adjustments. We could disclose its existence to atanasj (with a warning) so that he can use it for its qmd and rmd files as soon as possible.

However, I think that ultimately it would be better to convert `denote--file-types` to `denote-file-types` as-is, even if it contains more than just a front-matter. It must also contains entries like title-key-regexp and keywords-key-regexp. I will use an example to illustrate the issue here. Let's say we have an Org front-matter as fixed by `denote-org-front-matter`. Internally, we need to look for a `#+title:` line. But it is also desirable that we tolerate a `#title    :` line. We could try to guess a forgiving title-key-regexp ourselves from the front matter, but we cannot predict all potential file types that users will create. I think we should let the users control this themselves.

Also, we must not forget that this user option would be for advanced users. Having a little complexity in it might not be too bad.