### PR TITLE
Update denote--retrieve-filename-title: remove dashes and capitalize

### DIFF
--- a/denote.el
+++ b/denote.el
@@ -795,9 +795,10 @@ contain the newline."
   "Extract title from FILE name, else return `file-name-base'"
   (if (and (file-exists-p file)
            (denote--file-has-identifier-p file))
-      (progn
-        (string-match denote--title-regexp file)
-        (match-string 1 file))
+      (let ((file-title (progn
+                          (string-match denote--title-regexp file)
+                          (match-string 1 file))))
+             (capitalize (replace-regexp-in-string "-" " " file-title)))
     (file-name-base file)))
 
 (defun denote--retrieve-title-value (file file-type)


### PR DESCRIPTION
I made some changes to denote--retrieve-filename-title to replace dashes with spaces and capitalise the link title for better typography when linking Denote attachments.