### PR TITLE
Add option denote-date-prompt-use-org-read-date

### DIFF
--- a/denote.el
+++ b/denote.el
@@ -1128,9 +1128,12 @@ here for clarity."
 (defvar denote--date-history nil
   "Minibuffer history of `denote--date-prompt'.")
 
+(declare-function org-read-date "org" &optional with-time to-time from-string prompt default-time default-input inactive)
+
 (defun denote--date-prompt ()
   "Prompt for date."
-  (if denote-date-prompt-use-org-read-date
+  (if (and denote-date-prompt-use-org-read-date
+           (require 'org nil :no-error))
       (let* ((time (org-read-date nil t))
              (org-time-seconds (format-time-string "%S" time))
              (cur-time-seconds (format-time-string "%S" (current-time))))

--- a/denote.el
+++ b/denote.el
@@ -316,6 +316,16 @@ are described in the doc string of `format-time-string'."
   :package-version '(denote . "0.2.0")
   :group 'denote)
 
+(defcustom denote-date-prompt-use-org-read-date nil
+  "Whether to use `org-read-date' in date prompts.
+
+If non-nil, use `org-read-date'.
+
+If nil, input the date as a string, as described in `denote'."
+  :group 'denote
+  :package-version '(denote . "0.6.0")
+  :type 'boolean)
+
 (defcustom denote-templates nil
   "Alist of content templates for new notes.
 A template is arbitrary text that Denote will add to a newly
@@ -1120,9 +1130,11 @@ here for clarity."
 
 (defun denote--date-prompt ()
   "Prompt for date."
-  (read-string
-   "DATE and TIME for note (e.g. 2022-06-16 14:30): "
-   nil 'denote--date-history))
+  (if denote-date-prompt-use-org-read-date
+      (format-time-string "%Y-%m-%d %H:%M:%S" (org-read-date nil t))
+    (read-string
+     "DATE and TIME for note (e.g. 2022-06-16 14:30): "
+     nil 'denote--date-history)))
 
 (defvar denote--subdir-history nil
   "Minibuffer history of `denote--subdirs-prompt'.")

--- a/denote.el
+++ b/denote.el
@@ -1131,10 +1131,13 @@ here for clarity."
 (defun denote--date-prompt ()
   "Prompt for date."
   (if denote-date-prompt-use-org-read-date
-      (let* ((org-time (org-read-date nil t))
-             (current-seconds (string-to-number
-                               (format-time-string "%S" (current-time))))
-             (time (time-add org-time current-seconds)))
+      (let* ((time (org-read-date nil t))
+             (org-time-seconds (format-time-string "%S" time))
+             (cur-time-seconds (format-time-string "%S" (current-time))))
+        ;; When the user does not input a time, org-read-date defaults to 00 for seconds.
+        ;; When the seconds are 00, we add the current seconds to avoid identifier collisions.
+        (when (string-equal "00" org-time-seconds)
+          (setq time (time-add time (string-to-number cur-time-seconds))))
         (format-time-string "%Y-%m-%d %H:%M:%S" time))
     (read-string
      "DATE and TIME for note (e.g. 2022-06-16 14:30): "

--- a/denote.el
+++ b/denote.el
@@ -1131,7 +1131,11 @@ here for clarity."
 (defun denote--date-prompt ()
   "Prompt for date."
   (if denote-date-prompt-use-org-read-date
-      (format-time-string "%Y-%m-%d %H:%M:%S" (org-read-date nil t))
+      (let* ((org-time (org-read-date nil t))
+             (current-seconds (string-to-number
+                               (format-time-string "%S" (current-time))))
+             (time (time-add org-time current-seconds)))
+        (format-time-string "%Y-%m-%d %H:%M:%S" time))
     (read-string
      "DATE and TIME for note (e.g. 2022-06-16 14:30): "
      nil 'denote--date-history)))


### PR DESCRIPTION
As discussed in #95, this adds the option `denote-date-prompt-use-org-read-date`.

Note that `org-read-date`, when given no timestamp defaults to the current time, which would be good. However, the default seconds are always `00`. Defaulting to the current time for everything but the seconds is documented in their docstring. I have done nothing special to handle this better. This implies that a user who would create two notes within the same minute would have a conflicting identifier.

Given this, I am not sure if it would be better not to provide this option or to document this limitation.

Also, I did not load `org-read-date` conditionally to org being loaded because I did not know how to do it properly.