### PR TITLE
Also remove leading dash when sluggifying title.

### DIFF
--- a/denote.el
+++ b/denote.el
@@ -403,9 +403,9 @@ things accordingly.")
 (defun denote--slug-hyphenate (str)
   "Replace spaces and underscores with hyphens in STR.
 Also replace multiple hyphens with a single one and remove any
-trailing hyphen."
+leading and trailing hyphen."
   (replace-regexp-in-string
-   "-$" ""
+   "^-\\|-$" ""
    (replace-regexp-in-string
     "-\\{2,\\}" "-"
     (replace-regexp-in-string "_\\|\s+" "-" str))))


### PR DESCRIPTION
Slight update to `denote--slug-hyphenate` to also remove leading dashes. Use case: file names wit tripple dashes when accidentally adding spaces at start of title/