### PR TITLE
Return empty string when no keywords in org notes

### DIFF
--- a/denote.el
+++ b/denote.el
@@ -646,7 +646,9 @@ identifier: %s
 
 (defun denote--format-keywords-for-org-front-matter (keywords)
   "Format front matter KEYWORDS for org file type."
-  (format ":%s:" (string-join keywords ":")))
+  (if keywords
+      (format ":%s:" (string-join keywords ":"))
+    ""))
 
 (defun denote--extract-keywords-from-front-matter (keywords-string)
   "Extract keywords list from front matter KEYWORDS-STRING."


### PR DESCRIPTION
I am not sure of the right syntax when there are no keywords in an org file, but `::` looks strange. An empty string seems more appropriate, but I could not find documentation on this.