### PR TITLE
Added a prompt to denote-rename-file-using-front-matter.

### DIFF
--- a/denote.el
+++ b/denote.el
@@ -1602,7 +1602,9 @@ the source of truth in this case to avoid potential breakage with
 typos and the like."
   (interactive (list (buffer-file-name)))
   (when (buffer-modified-p)
-    (user-error "Save buffer before proceeding"))
+    (if (y-or-n-p "Would you like to save the buffer?")
+        (save-buffer)
+      (user-error "Save buffer before proceeding")))
   (unless (denote--writable-and-supported-p file)
     (user-error "The file is not writable or does not have a supported file extension"))
   (if-let* ((file-type (denote--filetype-heuristics file))


### PR DESCRIPTION
Hi Prot,

I have been using `denote-rename-file-using-front-matter` quite a bite and kept forgetting to save before evoking it so I added a prompt to the function for convenience.

P:)