### PR TITLE
Add denote-link-add-missing-links

### DIFF
--- a/README.org
+++ b/README.org
@@ -1204,6 +1204,17 @@ above is for interactive usage.
 Links are created only for files which qualify as a "note" for our
 purposes ([[#h:fc913d54-26c8-4c41-be86-999839e8ad31][Linking notes]]).
 
+** Insert links, but only those missing from current buffer
+
+#+findex: denote-link-add-missing-links
+As a variation on the =denote-link-add-links= function, one may wish to
+only include 'missing links', i.e. links that are not yet present in
+the current file.
+
+This can be achieved with =denote-link-add-missing-links=. The function
+is similar to =denote-link-add-links=, but will only include links to
+notes that are not yet linked to.
+
 ** Insert links from marked files in Dired
 :PROPERTIES:
 :CUSTOM_ID: h:9cbb692e-5d8a-44a6-9193-899a07872a07

--- a/denote.el
+++ b/denote.el
@@ -2518,6 +2518,30 @@ inserts links with just the identifier."
 
 (defalias 'denote-link-insert-links-matching-regexp (symbol-function 'denote-link-add-links))
 
+;;;###autoload
+(defun denote-link-add-missing-links (regexp &optional id-only)
+  "Insert missing links to all notes matching REGEXP.
+Similar to `denote-link-add-links' but insert only links not yet
+present in the current buffer.
+
+Optional ID-ONLY has the same meaning as in `denote-link': it
+inserts links with just the identifier."
+  (interactive
+   (list
+    (read-regexp "Insert links matching REGEX: " nil 'denote-link--add-links-history)
+    current-prefix-arg))
+  (let* ((current-file (buffer-file-name))
+         (current-id (denote-link--file-type-regexp current-file))
+         (linked-files (denote-link--expand-identifiers current-id)))
+    (if-let* ((found-files (delete current-file
+                                  (denote-directory-files-matching-regexp regexp)))
+              (final-files (seq-difference found-files linked-files)))
+        (let ((beg (point)))
+          (insert (denote-link--prepare-links final-files current-file id-only))
+          (unless (derived-mode-p 'org-mode)
+            (denote-link-buttonize-buffer beg (point))))
+      (user-error "No links matching `%s' that aren't yet present in the current buffer." regexp))))
+
 ;;;;; Links from Dired marks
 
 ;; NOTE 2022-07-21: I don't think we need a history for this one.


### PR DESCRIPTION
Similar to `denote-link-add-missing-links', but only insert links that are not yet included in the current buffer.