### PR TITLE
Fix broken link during exportation

### DIFF
--- a/denote.el
+++ b/denote.el
@@ -3078,7 +3078,7 @@ interface by first selecting the `denote:' hyperlink type."
 The LINK, DESCRIPTION, and FORMAT are handled by the export
 backend."
   (let* ((path-id (denote-link--ol-resolve-link-to-target link :path-id))
-         (path (file-name-nondirectory (car path-id)))
+         (path (file-relative-name (car path-id)))
          (p (file-name-sans-extension path))
          (id (cdr path-id))
          (desc (or description (concat "denote:" id))))


### PR DESCRIPTION
First I would like to thank you for this wonderful work, I am just getting started with denote and really liking it so far.

I want to use denote to  manage a part of my personal website, where I want to keep track of personal notes on various scientific topics. My entire website is generated with org, but not everything is managed with denote. A use case that I have is that I sometimes need to link to a note from the main part of the website. My internal organization is to have the denote part as a subfolder with the denote entries, inside my folder with the other org documents. When I do this with denote links, the link works just fine in org but gets broken during the export, because the generated link assumes that the file it points belongs to the same directory.

The fix I submitted is very simple and just changes this assumption to generate a relative file name using the built-in function of emacs