### PR TITLE
Fix broken link to jao's blog

### DIFF
--- a/README.org
+++ b/README.org
@@ -3621,7 +3621,7 @@ unsorted.
 
 + José Antonio Ortega Ruiz (aka "jao") explains a note-taking method
   that is simple like Denote but differs in other ways.  An interesting
-  approach overall: https://jao.io/blog/2022-06-19-simple-note-taking.html.
+  approach overall: https://jao.io/blog/simple-note-taking.html.
 
 + Jethro Kuan (the main =org-roam= developer) explains their note-taking
   techniques: https://jethrokuan.github.io/org-roam-guide/.  Good ideas


### PR DESCRIPTION
Hello Prot!

Hope you are well. Why perusing README of your denote package I noticed that the page under https://jao.io/blog/2022-06-19-simple-note-taking.html does not exist. This PR should fix that.

Best regards
Tomasz Hołubowicz