### PR TITLE
Duplicate ids

### DIFF
--- a/README.org
+++ b/README.org
@@ -3038,7 +3038,7 @@ invoke this command."
   (image-dired--with-marked
    (when-let* ((file (image-dired-original-file-name))
                (dir (file-name-directory file))
-               (id (denote-retrieve-or-create-file-identifier file))
+               (id (denote-retrieve-filename-identifier file))
                (file-type (denote-filetype-heuristics file))
                (title (denote--retrieve-title-or-filename file file-type))
                (extension (file-name-extension file t))
@@ -3626,34 +3626,28 @@ might change them without further notice.
 
 #+findex: denote-retrieve-filename-identifier
 + Function ~denote-retrieve-filename-identifier~ :: Extract identifier
-  from =FILE= name.  To return an existing identifier or create a new
-  one, refer to the ~denote-retrieve-or-create-file-identifier~
-  function.
+  from =FILE= name.  To create a new one, refer to the
+  ~denote-create-unique-file-identifier~ function.
 
 #+findex: denote-retrieve-filename-signature
 + Function ~denote-retrieve-filename-signature~ :: Extract signature
   from =FILE= name, if present, else return nil.
 
-#+findex: denote-retrieve-or-create-file-identifier
-+ Function ~denote-retrieve-or-create-file-identifier~ :: Return
-  =FILE= identifier, generating one if appropriate.  The conditions
-  are as follows:
+#+findex: denote-create-unique-file-identifier
++ Function ~denote-create-unique-file-identifier~ :: Create a new unique
+  =FILE= identifier.  The conditions are as follows:
 
-  - If =FILE= has an identifier, return it.
+  - If =DATE= is non-nil, invoke ~denote-prompt-for-date-return-id~.
 
-  - If =FILE= does not have an identifier and optional =DATE= is
-    non-nil, invoke ~denote-prompt-for-date-return-id~.
-
-  - If =FILE= does not have an identifier and DATE is nil, use the
-    file attributes to determine the last modified date and format it
-    as an identifier.
+  - If =DATE= is nil, use the file attributes to determine the last
+    modified date and format it as an identifier.
 
   - As a fallback, derive an identifier from the current time.
   
-  With optional =FILES= as a list of file names, test that the
+  With optional =USED-IDS= as a hash table of identifiers, test that the
   identifier is unique among them.
 
-  With optional =FILES= as non-nil, test that the identifier is unique
+  With optional =USED-IDS= as nil, test that the identifier is unique
   among all files and buffers in variable ~denote-directory~.
 
   To only return an existing identifier, refer to the function

--- a/denote.el
+++ b/denote.el
@@ -1674,7 +1674,7 @@ It checks files in variable `denote-directory' and active buffer files."
                       (denote-directory-files)))
          (names (append file-names (denote--buffer-file-names))))
     (dolist (name names)
-      (let ((id (when (string-match (concat "\\`" denote--id-regexp) name)
+      (let ((id (when (string-match (concat "\\`" denote-id-regexp) name)
                   (match-string-no-properties 0 name))))
         (puthash id t ids)))
     ids))
@@ -1685,10 +1685,10 @@ USED-IDS is a hash-table of all used IDs. If ID is already used,
 increment it 1 second at a time until an available id is found."
   (let ((time (date-to-time id)))
     (while (gethash
-            (format-time-string denote--id-format time)
+            (format-time-string denote-id-format time)
             used-ids)
       (setq time (time-add time 1)))
-    (format-time-string denote--id-format time)))
+    (format-time-string denote-id-format time)))
 
 (define-obsolete-function-alias
   'denote--barf-duplicate-id

--- a/denote.el
+++ b/denote.el
@@ -1662,6 +1662,31 @@ where the former does not read dates without a time component."
      (string-prefix-p identifier (file-name-nondirectory file)))
    (append (denote-directory-files) (denote--buffer-file-names))))
 
+(defun denote--get-all-used-ids ()
+  "Return a hash-table of all used identifiers.
+It checks files in variable `denote-directory' and active buffer files."
+  (let* ((ids (make-hash-table :test 'equal))
+         (file-names (mapcar
+                      (lambda (file) (file-name-nondirectory file))
+                      (denote-directory-files)))
+         (names (append file-names (denote--buffer-file-names))))
+    (dolist (name names)
+      (let ((id (when (string-match (concat "\\`" denote--id-regexp) name)
+                  (match-string-no-properties 0 name))))
+        (puthash id t ids)))
+    ids))
+
+(defun denote--find-first-unused-id (id used-ids)
+  "Return the first unused id starting at ID from USED-IDS.
+USED-IDS is a hash-table of all used IDs. If ID is already used,
+increment it 1 second at a time until an available id is found."
+  (let ((time (date-to-time id)))
+    (while (gethash
+            (format-time-string denote--id-format time)
+            used-ids)
+      (setq time (time-add time 1)))
+    (format-time-string denote--id-format time)))
+
 (defun denote--increment-identifier (identifier)
   "Increment IDENTIFIER.
 Preserve the date component and append to it the current time."

--- a/denote.el
+++ b/denote.el
@@ -1334,15 +1334,18 @@ contain the newline."
 
 ;;;; Front matter or content retrieval functions
 
-(defun denote-retrieve-filename-identifier (file)
+(defun denote-retrieve-filename-identifier (file &optional no-error)
   "Extract identifier from FILE name.
-To return an existing identifier or create a new one, refer to
-the function `denote-retrieve-or-create-file-identifier'."
-  (if (denote-file-has-identifier-p file)
-      (progn
-        (string-match denote-id-regexp file)
-        (match-string 0 file))
-    (error "Cannot find `%s' as a file with a Denote identifier" file)))
+If NO-ERROR is nil and an identifier is not found, return an
+error, else return nil.
+
+To create a new one, refer to the function
+`denote-create-unique-file-identifier'."
+  (let ((file-name (file-name-nondirectory file)))
+    (if (string-match (concat "\\`" denote-id-regexp) file-name)
+        (match-string-no-properties 0 file-name)
+      (when (not no-error)
+        (error "Cannot find `%s' as a file with a Denote identifier" file)))))
 
 (define-obsolete-function-alias
   'denote--retrieve-filename-identifier

--- a/denote.el
+++ b/denote.el
@@ -1690,19 +1690,6 @@ increment it 1 second at a time until an available id is found."
       (setq time (time-add time 1)))
     (format-time-string denote--id-format time)))
 
-(defun denote--increment-identifier (identifier)
-  "Increment IDENTIFIER.
-Preserve the date component and append to it the current time."
-  (let* ((datetime (split-string identifier "T"))
-         (date (car datetime)))
-    (concat date "T" (format-time-string "%H%M%S"))))
-
-(defun denote--return-new-identifier-if-duplicate (identifier)
-  "Return new unique identifier if IDENTIFIER already exists."
-  (while (denote--id-exists-p identifier)
-    (setq identifier (denote--increment-identifier identifier)))
-  identifier)
-
 (define-obsolete-function-alias
   'denote--barf-duplicate-id
   'denote-barf-duplicate-id


### PR DESCRIPTION
Hi Prot,

I saw the changes about unique ids. I suggest this solution below. My
goal was to make ids robust everywhere, fast and without optional
parameters or options.

Affected functions:
- `denote`: Always creates a new unused id (see how below). No need to
  barf anymore.
- `denote-org-capture-with-prompts`: Always creates a new unused id. No
  need to barf anymore.
- `denote-barf-duplicate-id`: Obsolete as it is not used anymore.
- `denote-retrieve-or-create-file-identifier`: Removed. Use the
  functions 'denote-retrieve-filename-identifier' (already exists) and
  'denote-create-unique-file-identifier' (new).
- `denote-retrieve-filename-identifier`: New optional parameter
  'no-error' to return nil instead of an error.
- `denote-create-unique-file-identifier`: New.
- `denote-change-file-type`: Minor change. We do not check for
  duplicate ids in this case. We now enforce that the file must have an
  identifier in its name.
- `denote-add-front-matter`: Minor change. Do not check for duplicate
  ids. It does not rename a file anyway, by design.
- `denote-rename-file`: We now check for duplicate ids. Should be as
  fast as the current solution. In fact, if the renamed file already has
  an id, we do not check for duplicate ids, so this should be faster.
- `denote-rename-file-using-from-matter`: If, somehow, the file name
  did not already have an identifier, this function created one that
  was not necessarily unique. Now, we check and make sure it is unique.
  This is slower than before, but no more than the 'denote' command and
  only if the file lacks an identifier.
- `denote-dired-rename-marked-files`: Ensure ids are unique by checking
  against all denote notes. This may be slower than the current
  solution, but it is not slower than a single 'denote' command and this
  check only happens when there is a file without id.
- `denote-dired-rename-marked-files-using-from-matter`: The doc said
  that files without an id are ignored, but this was not enforced. A new
  identifier is created if none is present. I modified the function to
  enforce this.

The solution:
- Use a hash table for used ids. In the general case (when there is no
  duplicate ids), the `denote` function already had to go through ALL
  denote notes and compare with their ids. The modification I made
  should not be significantly slower, if at all.
- The way to find a new unique identifier has changed. In the current
  version, the current time is used. In my proposed solution, I just
  increment the identifier by 1 second until an unused id is found.

I have not tested the affected functions extensively. Please, do some
quick tests before merging.

Good day!