### PR TITLE
Small cleanup

### DIFF
--- a/denote.el
+++ b/denote.el
@@ -1535,11 +1535,10 @@ creation."
       (insert template))))
 
 (defun denote--dir-in-denote-directory-p (directory)
-  "Return DIRECTORY if in variable `denote-directory', else nil."
-  (when (and directory
-             (string-prefix-p (denote-directory)
-                              (expand-file-name directory)))
-    directory))
+  "Return non-nil if DIRECTORY is in variable `denote-directory'."
+  (and directory
+       (string-prefix-p (denote-directory)
+                        (expand-file-name directory))))
 
 (defun denote--valid-file-type (filetype)
   "Return a valid filetype given the argument FILETYPE.

--- a/denote.el
+++ b/denote.el
@@ -748,13 +748,10 @@ FILE must be an absolute path."
   (when (string-match denote-id-regexp string)
     (match-string 0 string)))
 
-;; TODO 2022-09-26: Maybe we can consolidate this with
-;; `denote--dir-in-denote-directory-p'?  Another check for the
-;; directory prefix is done in `denote-file-is-note-p'.
-(defun denote--default-dir-has-denote-prefix ()
-  "Test `default-directory' for variable `denote-directory' prefix."
-  (string-prefix-p (denote-directory)
-                   (expand-file-name default-directory)))
+(define-obsolete-function-alias
+  'denote--default-dir-has-denote-prefix
+  'denote--dir-in-denote-directory-p
+  "2.1.0")
 
 (defun denote--exclude-directory-regexp-p (file)
   "Return non-nil if FILE matches `denote-excluded-directories-regexp'."
@@ -2087,7 +2084,7 @@ the file type is assumed to be the first of `denote-file-types'."
    (lambda (buf)
      (with-current-buffer buf
        (when (and (eq major-mode 'dired-mode)
-                  (denote--default-dir-has-denote-prefix))
+                  (denote--dir-in-denote-directory-p default-directory))
          (revert-buffer))))
    (buffer-list)))
 


### PR DESCRIPTION
I checked and removed the function `denote--default-dir-has-denote-prefix' as it does not seem necessary. I also simplified `denote--dir-in-denote-directory-p'. The returned value is not used.