### PR TITLE
Small refactor

### DIFF
--- a/README.org
+++ b/README.org
@@ -3827,7 +3827,8 @@ might change them without further notice.
 
 #+findex: denote-create-unique-file-identifier
 + Function ~denote-create-unique-file-identifier~ :: Create a new unique
-  =FILE= identifier.  The conditions are as follows:
+  =FILE= identifier.  Test that the identifier is unique among
+  =USED-IDS=.  The conditions are as follows:
 
   - If =DATE= is non-nil, invoke ~denote-prompt-for-date-return-id~.
 
@@ -3835,9 +3836,6 @@ might change them without further notice.
     modified date and format it as an identifier.
 
   - As a fallback, derive an identifier from the current time.
-
-  With optional =USED-IDS= as a hash table of identifiers, test that the
-  identifier is unique among them.
 
   With optional =USED-IDS= as nil, test that the identifier is unique
   among all files and buffers in variable ~denote-directory~.

--- a/denote.el
+++ b/denote.el
@@ -2581,24 +2581,18 @@ does internally."
     (user-error "The file is not writable or does not have a supported file extension"))
   (if-let ((file-type (denote-filetype-heuristics file))
            (title (denote-retrieve-title-value file file-type))
-           (extension (denote-get-file-extension file))
-           (id (or (denote-retrieve-filename-identifier file :no-error)
-                   (denote-create-unique-file-identifier file)))
-           (dir (file-name-directory file))
-           (new-name (denote-format-file-name
-                      ;; The `denote-retrieve-keywords-value' and
-                      ;; `denote-retrieve-filename-signature' are not
-                      ;; inside the `if-let' because we do not want
-                      ;; to throw an exception if any is nil.
-                      dir id
-                      (or (denote-retrieve-keywords-value file file-type) nil)
-                      (denote-sluggify title 'title) extension
-                      (or (denote-retrieve-filename-signature file) nil))))
-      (when (or auto-confirm
-                (denote-rename-file-prompt file new-name))
-        (denote-rename-file-and-buffer file new-name)
-        (denote-update-dired-buffers))
-    (user-error "No front matter for title and/or keywords")))
+           (id (denote-retrieve-filename-identifier file :no-error)))
+      (let* ((sluggified-title (denote-sluggify title 'title))
+             (keywords (denote-retrieve-keywords-value file file-type))
+             (signature (denote-retrieve-filename-signature file))
+             (extension (denote-get-file-extension file))
+             (dir (file-name-directory file))
+             (new-name (denote-format-file-name dir id keywords sluggified-title extension signature)))
+        (when (or auto-confirm
+                  (denote-rename-file-prompt file new-name))
+          (denote-rename-file-and-buffer file new-name)
+          (denote-update-dired-buffers)))
+    (user-error "No identifier or front matter for title")))
 
 ;;;###autoload
 (defun denote-dired-rename-marked-files-using-front-matter ()

--- a/denote.el
+++ b/denote.el
@@ -1366,8 +1366,8 @@ To create a new one, refer to the function
       (when (not no-error)
         (error "Cannot find `%s' as a file with a Denote identifier" file)))))
 
-(defun denote-create-unique-file-identifier (file &optional date used-ids)
-  "Generate a unique identifier for FILE.
+(defun denote-create-unique-file-identifier (file used-ids &optional date)
+  "Generate a unique identifier for FILE not in USED-IDS hash-table.
 
 The conditions are as follows:
 
@@ -1379,18 +1379,13 @@ The conditions are as follows:
 
 - As a fallback, derive an identifier from the current time.
 
-If USED-IDS hash-table is non-nil, use it, else create and
-populate a new one.
-
 To only return an existing identifier, refer to the function
 `denote-retrieve-filename-identifier'."
   (let ((id (cond
              (date (denote-prompt-for-date-return-id))
              ((denote--file-attributes-time file))
              (t (format-time-string denote-id-format)))))
-    (if used-ids
-        (denote--find-first-unused-id id used-ids)
-      (denote--find-first-unused-id id (denote--get-all-used-ids)))))
+    (denote--find-first-unused-id id used-ids)))
 
 (define-obsolete-function-alias
   'denote-retrieve-or-create-file-identifier
@@ -2437,7 +2432,7 @@ place."
       current-prefix-arg)))
   (let* ((dir (file-name-directory file))
          (id (or (denote-retrieve-filename-identifier file :no-error)
-                 (denote-create-unique-file-identifier file ask-date)))
+                 (denote-create-unique-file-identifier file (denote--get-all-used-ids) ask-date)))
          (extension (denote-get-file-extension file))
          (file-type (denote-filetype-heuristics file))
          (title (or title (denote--retrieve-title-or-filename file file-type)))
@@ -2473,7 +2468,7 @@ the changes made to the file: perform them outright."
                  (file-in-prompt (propertize file 'face 'error))
                  (dir (file-name-directory file))
                  (id (or (denote-retrieve-filename-identifier file :no-error)
-                         (denote-create-unique-file-identifier file nil used-ids)))
+                         (denote-create-unique-file-identifier file used-ids)))
                  (title (denote-title-prompt
                          (denote--retrieve-title-or-filename file file-type)
                          (format "Rename `%s' with title" file-in-prompt)))
@@ -2539,7 +2534,7 @@ Specifically, do the following:
         (dolist (file marks)
           (let* ((dir (file-name-directory file))
                  (id (or (denote-retrieve-filename-identifier file :no-error)
-                         (denote-create-unique-file-identifier file nil used-ids)))
+                         (denote-create-unique-file-identifier file used-ids)))
                  (signature (denote-retrieve-filename-signature file))
                  (file-type (denote-filetype-heuristics file))
                  (title (denote--retrieve-title-or-filename file file-type))


### PR DESCRIPTION
Nothing major. I just refactored `denote-rename-file-using-front-matter` and I made `used-ids` parameter non optional in `denote-create-unique-filename-identifier`. This will force us to use `denote--get-all-used-ids` whenever we want to use it. In general, when we would use `denote-create-unique-filename-identifier` without `used-ids`, there was a risk that we would introduce some performance issues. Now, it will be more obvious if we do so.

I think it is all good for 2.1.0!