### PR TITLE
Refactor

### DIFF
--- a/README.org
+++ b/README.org
@@ -3957,30 +3957,30 @@ might change them without further notice.
   To only return an existing identifier, refer to the function
   ~denote-retrieve-filename-identifier~.
 
-#+findex: denote-retrieve-title-value
-+ Function ~denote-retrieve-title-value~ :: Return title value from
+#+findex: denote-retrieve-front-matter-title-value
++ Function ~denote-retrieve-front-matter-title-value~ :: Return title value from
   =FILE= front matter per =FILE-TYPE=.
 
-#+findex: denote-retrieve-title-line
-+ Function ~denote-retrieve-title-line~ :: Return title line from
+#+findex: denote-retrieve-front-matter-title-line
++ Function ~denote-retrieve-front-matter-title-line~ :: Return title line from
   =FILE= front matter per =FILE-TYPE=.
 
-#+findex: denote-retrieve-keywords-value
-+ Function ~denote-retrieve-keywords-value~ :: Return keywords value
+#+findex: denote-retrieve-front-matter-keywords-value
++ Function ~denote-retrieve-front-matter-keywords-value~ :: Return keywords value
   from =FILE= front matter per =FILE-TYPE=. The return value is a list
   of strings. To get a combined string the way it would appear in a
-  Denote file name, use ~denote-retrieve-keywords-value-as-string~.
+  Denote file name, use ~denote-retrieve-front-matter-keywords-value-as-string~.
 
-#+findex: denote-retrieve-keywords-value-as-string
-+ Function ~denote-retrieve-keywords-value-as-string~ :: Return
+#+findex: denote-retrieve-front-matter-keywords-value-as-string
++ Function ~denote-retrieve-front-matter-keywords-value-as-string~ :: Return
   keywords value from =FILE= front matter per =FILE-TYPE=. The return
   value is a string, with the underscrore as a separator between
   individual keywords. To get a list of strings instead, use
-  ~denote-retrieve-keywords-value~ (the current function uses that
+  ~denote-retrieve-front-matter-keywords-value~ (the current function uses that
   internally).
 
-#+findex: denote-retrieve-keywords-line
-+ Function ~denote-retrieve-keywords-line~ :: Return keywords line
+#+findex: denote-retrieve-front-matter-keywords-line
++ Function ~denote-retrieve-front-matter-keywords-line~ :: Return keywords line
   from =FILE= front matter per =FILE-TYPE=.
 
 #+findex: denote-signature-prompt

--- a/README.org
+++ b/README.org
@@ -3297,10 +3297,10 @@ invoke this command."
   (image-dired--with-marked
    (when-let* ((file (image-dired-original-file-name))
                (dir (file-name-directory file))
-               (id (denote-retrieve-filename-identifier file))
+               (id (or (denote-retrieve-filename-identifier file) ""))
                (file-type (denote-filetype-heuristics file))
                (title (denote--retrieve-title-or-filename file file-type))
-               (signature (denote-retrieve-filename-signature file))
+               (signature (or (denote-retrieve-filename-signature file) "")
                (extension (file-name-extension file t))
                (new-name (denote-format-file-name dir id keywords title extension signature))
                (default-directory dir))
@@ -3923,25 +3923,21 @@ might change them without further notice.
 
 #+findex: denote-retrieve-filename-identifier
 + Function ~denote-retrieve-filename-identifier~ :: Extract identifier
-  from =FILE= name.  To create a new one, refer to the
+  from =FILE= name, if present, else return nil.  To create a new one, refer to the
   ~denote-create-unique-file-identifier~ function.
 
 #+findex: denote-retrieve-filename-title
 + Function ~denote-retrieve-filename-title~ ::  Extract Denote title
-  component from =FILE= name, else return an empty string. With
-  optional =FILE-NAME-BASE-FALLBACK= return ~file-name-base~ if no
-  Denote title component exists. If the extraction is succcessful
-  (when no ~file-name-base~ is involved) run ~denote-desluggify~ on
-  the title.
+  component from =FILE= name, if present, else return nil.
 
 #+findex: denote-retrieve-filename-keywords
 + Function ~denote-retrieve-filename-keywords~ ::  Extract keywords
-  from =FILE= name, if present, else return an empty string. Return
+  from =FILE= name, if present, else return nil. Return
   matched keywords as a single string.
 
 #+findex: denote-retrieve-filename-signature
 + Function ~denote-retrieve-filename-signature~ :: Extract signature
-  from =FILE= name, if present, else return an empty string.
+  from =FILE= name, if present, else return nil.
 
 #+findex: denote-create-unique-file-identifier
 + Function ~denote-create-unique-file-identifier~ :: Create a new unique

--- a/denote-org-dblock.el
+++ b/denote-org-dblock.el
@@ -196,17 +196,11 @@ component.  If the symbol is not among `denote-sort-components',
 fall back to the default identifier-based sorting.
 
 If optional REVERSE is non-nil reverse the sort order."
-  (let ((files (denote-org-dblock--files regexp sort-by-component reverse)))
-    ;; FIXME 2023-11-23: Do not use a separator for the last file.
-    ;; Not a big issue, but is worth checking.
-    (mapc
-     (lambda (file)
-       ;; NOTE 2023-11-23: I tried to just do `insert-file-contents'
-       ;; without the temporary buffer, but it seems that the point is
-       ;; not moved, so the SEPARATOR does not follow the contents.
-       (let ((contents (denote-org-dblock--get-file-contents file no-front-matter add-links)))
-         (insert (concat contents (denote-org-dblock--separator separator)))))
-     files)))
+  (let* ((files (denote-org-dblock--files regexp sort-by-component reverse))
+         (files-contents (mapcar
+                          (lambda (file) (denote-org-dblock--get-file-contents file no-front-matter add-links))
+                          files)))
+    (insert (string-join files-contents (denote-org-dblock--separator separator)))))
 
 ;;;###autoload
 (defun denote-org-dblock-insert-files (regexp sort-by-component)

--- a/denote-rename-buffer.el
+++ b/denote-rename-buffer.el
@@ -94,11 +94,11 @@ buffer will be used, if available."
              (type (denote-filetype-heuristics file)))
     (string-trim
      (format-spec denote-rename-buffer-format
-                  (list (cons ?t (denote-retrieve-title-value file type))
-                        (cons ?i (denote-retrieve-filename-identifier file))
-                        (cons ?d (denote-retrieve-filename-identifier file))
-                        (cons ?s (denote-retrieve-filename-signature file))
-                        (cons ?k (denote-retrieve-keywords-value-as-string file type))
+                  (list (cons ?t (or (denote-retrieve-title-value file type) ""))
+                        (cons ?i (or (denote-retrieve-filename-identifier file) ""))
+                        (cons ?d (or (denote-retrieve-filename-identifier file) ""))
+                        (cons ?s (or (denote-retrieve-filename-signature file) ""))
+                        (cons ?k (or (denote-retrieve-keywords-value-as-string file type) ""))
                         (cons ?% "%"))
                   'delete))))
 

--- a/denote-rename-buffer.el
+++ b/denote-rename-buffer.el
@@ -94,11 +94,11 @@ buffer will be used, if available."
              (type (denote-filetype-heuristics file)))
     (string-trim
      (format-spec denote-rename-buffer-format
-                  (list (cons ?t (or (denote-retrieve-title-value file type) ""))
+                  (list (cons ?t (or (denote-retrieve-front-matter-title-value file type) ""))
                         (cons ?i (or (denote-retrieve-filename-identifier file) ""))
                         (cons ?d (or (denote-retrieve-filename-identifier file) ""))
                         (cons ?s (or (denote-retrieve-filename-signature file) ""))
-                        (cons ?k (or (denote-retrieve-keywords-value-as-string file type) ""))
+                        (cons ?k (or (denote-retrieve-front-matter-keywords-value-as-string file type) ""))
                         (cons ?% "%"))
                   'delete))))
 

--- a/denote-sort.el
+++ b/denote-sort.el
@@ -58,8 +58,8 @@ two title values."
          component)
        (let* ((one (,retrieve-fn file1))
               (two (,retrieve-fn file2))
-              (one-empty-p (string-empty-p one))
-              (two-empty-p (string-empty-p two)))
+              (one-empty-p (or (null one) (string-empty-p one)))
+              (two-empty-p (or (null two) (string-empty-p two))))
          (cond
           (one-empty-p nil)
           ((and (not one-empty-p) two-empty-p) one)

--- a/denote.el
+++ b/denote.el
@@ -2719,12 +2719,10 @@ relevant front matter."
     (buffer-file-name)
     (denote-title-prompt)
     (denote-keywords-prompt)))
-  (when (and (denote-file-is-writable-and-supported-p file)
-             (denote-file-has-identifier-p file))
-    (denote--add-front-matter
-     file title keywords
-     (denote-retrieve-filename-identifier file)
-     (denote-filetype-heuristics file))))
+  (when-let ((denote-file-is-writable-and-supported-p file)
+             (id (denote-retrieve-filename-identifier file :no-error))
+             (file-type (denote-filetype-heuristics file)))
+    (denote--add-front-matter file title keywords id file-type)))
 
 (define-obsolete-function-alias
   'denote-change-file-type

--- a/denote.el
+++ b/denote.el
@@ -1499,25 +1499,20 @@ that internally)."
     (when (re-search-forward (denote--keywords-key-regexp file-type) nil t 1)
       (buffer-substring-no-properties (line-beginning-position) (line-end-position)))))
 
-(make-obsolete
- 'denote-retrieve-title-value
- 'denote-retrieve-front-matter-title-value
- "2.3.0")
+(defalias 'denote-retrieve-title-value 'denote-retrieve-front-matter-title-value
+ "Alias for `denote-retrieve-front-matter-title-value'.")
 
-(make-obsolete
- 'denote-retrieve-title-line
- 'denote-retrieve-front-matter-title-line
- "2.3.0")
+(defalias 'denote-retrieve-title-line 'denote-retrieve-front-matter-title-line
+ "Alias for `denote-retrieve-front-matter-title-line'.")
 
-(make-obsolete
- 'denote-retrieve-keywords-value
- 'denote-retrieve-front-matter-keywords-value
- "2.3.0")
+(defalias 'denote-retrieve-keywords-value 'denote-retrieve-front-matter-keywords-value
+ "Alias for `denote-retrieve-front-matter-keywords-value'.")
 
-(make-obsolete
- 'denote-retrieve-keywords-line
- 'denote-retrieve-front-matter-keywords-line
- "2.3.0")
+(defalias 'denote-retrieve-keywords-line 'denote-retrieve-front-matter-keywords-line
+ "Alias for `denote-retrieve-front-matter-keywords-line'.")
+
+(defalias 'denote-retrieve-keywords-value-as-string 'denote-retrieve-front-matter-keywords-value-as-string
+ "Alias for `denote-retrieve-front-matter-keywords-value-as-string'.")
 
 (defun denote--retrieve-title-or-filename (file type)
   "Return appropriate title for FILE given its TYPE."

--- a/denote.el
+++ b/denote.el
@@ -1846,8 +1846,7 @@ When called from Lisp, all arguments are optional.
   "Currently bound default title for `denote-title-prompt'.
 Set the value of this variable within the lexical scope of a
 command that needs to supply a default title before calling
-`denote-title-prompt' and use `unwind-protect' to set its value
-back to nil.")
+`denote-title-prompt'.")
 
 (defun denote-title-prompt (&optional default-title prompt-text)
   "Prompt for title string.
@@ -2106,13 +2105,9 @@ Set the `denote-title-prompt-current-default' to the last input.
 This is what makes commands such as `denote-open-or-create' or
 `denote-link-or-create' get what the user initially typed as the
 default value for the title of the new note to be created."
-  (let ((last-input (when denote--file-history
-                      (pop denote--file-history))))
-    (unwind-protect
-        (progn
-          (setq denote-title-prompt-current-default last-input)
-          (call-interactively command))
-      (setq denote-title-prompt-current-default nil))))
+  (let ((denote-title-prompt-current-default (when denote--file-history
+                                               (pop denote--file-history))))
+    (call-interactively command)))
 
 ;;;###autoload
 (defun denote-open-or-create (target)

--- a/denote.el
+++ b/denote.el
@@ -1378,9 +1378,9 @@ contain the newline."
 
 To create a new one, refer to the function
 `denote-create-unique-file-identifier'."
-  (let ((file-name (file-name-nondirectory file)))
-    (if (string-match (concat "\\`" denote-id-regexp) file-name)
-        (match-string-no-properties 0 file-name))))
+  (let ((filename (file-name-nondirectory file)))
+    (if (string-match (concat "\\`" denote-id-regexp) filename)
+        (match-string-no-properties 0 filename))))
 
 ;; TODO 2023-12-08: Maybe we can only use
 ;; `denote-retrieve-filename-identifier' and remove this function.

--- a/denote.el
+++ b/denote.el
@@ -2763,7 +2763,7 @@ of the file.  This needs to be done manually."
          (new-extension (denote--file-extension new-file-type))
          (new-name (denote-format-file-name
                     dir id keywords (denote-sluggify title 'title) new-extension signature))
-         (max-mini-window-height 0.33)) ; allow minibuffer to be resized
+         (max-mini-window-height denote-rename-max-mini-window-height))
     (when (and (not (eq old-extension new-extension))
                (denote-rename-file-prompt file new-name))
       (denote-rename-file-and-buffer file new-name)

--- a/denote.el
+++ b/denote.el
@@ -3988,10 +3988,44 @@ Consult the manual for template samples."
     (denote--keywords-add-to-history keywords)
     (concat front-matter template denote-org-capture-specifiers))))
 
-(make-obsolete
- 'denote-org-capture-with-prompts
- 'denote-org-capture
- "2.3.0")
+;; TODO 2023-12-02: Maybe simplify `denote-org-capture-with-prompts'
+;; by passing a single PROMPTS that is the same value as `denote-prompts'?
+
+;; TODO 2023-12-02: The `denote-org-capture-with-prompts' is missing a
+;; signature argument, but nobody has asked for it.  I think
+;; refactoring it per the above TODO is better, anyway.  But maybe do
+;; this after version 2.2.0 is out.
+
+;;;###autoload
+(defun denote-org-capture-with-prompts (&optional title keywords subdirectory date template)
+  "Like `denote-org-capture' but with optional prompt parameters.
+
+When called without arguments, do not prompt for anything.  Just
+return the front matter with title and keyword fields empty and
+the date and identifier fields specified.  Also make the file
+name consist of only the identifier plus the Org file name
+extension.
+
+Otherwise produce a minibuffer prompt for every non-nil value
+that corresponds to the TITLE, KEYWORDS, SUBDIRECTORY, DATE, and
+TEMPLATE arguments.  The prompts are those used by the standard
+`denote' command and all of its utility commands.
+
+When returning the contents that fill in the Org capture
+template, the sequence is as follows: front matter, TEMPLATE, and
+then the value of the user option `denote-org-capture-specifiers'.
+
+Important note: in the case of SUBDIRECTORY actual subdirectories
+must exist---Denote does not create them.  Same principle for
+TEMPLATE as templates must exist and are specified in the user
+option `denote-templates'."
+  (let ((denote-prompts '()))
+    (when template (push 'template denote-prompts))
+    (when date (push 'date denote-prompts))
+    (when subdirectory (push 'subdirectory denote-prompts))
+    (when keywords (push 'keywords denote-prompts))
+    (when title (push 'title denote-prompts))
+    (denote-org-capture)))
 
 (defun denote-org-capture-delete-empty-file ()
   "Delete file if capture with `denote-org-capture' is aborted."


### PR DESCRIPTION
Hello Prot!

This is a big pull request. No functional changes though.

- I have refactored `denote-file-has-identifier-p` to remove code
duplication.

- I have refactored `denote-add-front-matter`.

- I have streamlined the `denote-retrieve-filename-*` functions.
Previously, depending on the function, they were returning nil, an error
or an empty string when the element was not found. Now, they all do the
same thing and return nil when not found. I have adjusted the code
wherever they are called to handle the empty string and error cases.
Also, `denote-retrieve-filename-base` had an optional parameter to
fallback on the actual filename. I have done some refactoring to do this
work elsewhere (`denote--retrieve-title-or-filename`).

- I have renamed the functions `denote-retrieve-*-value` and
`denote-retrieve-*-line` to `denote-retrieve-front-matter-*-value` and
`denote-retrieve-front-matter-*-line` respectively so they are more like
the `denote-retrieve-filename-*` functions. Let me know if you think
this is an improvement. If not, I can remove this commit.

- I have removed `denote-org-capture-with-prompts` because I made
 `denote-org-capture` obey `denote-prompts`. It now handles signature
 as well.