### PR TITLE
Fix for denote-rename-file when signature has ='s for spaces.

### DIFF
--- a/denote.el
+++ b/denote.el
@@ -2496,6 +2496,7 @@ rename non-note files (e.g. PDF) that can benefit from Denote's
 file-naming scheme."
   (interactive
    (let* ((file (denote--rename-dired-file-or-prompt))
+          (spaced-signature (string-replace "=" " " (denote-retrieve-filename-signature file)))
           (file-type (denote-filetype-heuristics file))
           (file-in-prompt (propertize (file-relative-name file) 'face 'denote-faces-prompt-current-name)))
      (list
@@ -2506,7 +2507,7 @@ file-naming scheme."
       (denote-keywords-prompt
        (format "Rename `%s' with keywords (empty to ignore/remove)" file-in-prompt))
       (denote-signature-prompt
-       (denote-retrieve-filename-signature file)
+       spaced-signature
        (format "Rename `%s' with signature (empty to ignore/remove)" file-in-prompt))
       current-prefix-arg)))
   (let* ((dir (file-name-directory file))

--- a/denote.el
+++ b/denote.el
@@ -2660,7 +2660,7 @@ does internally."
            (id (denote-retrieve-filename-identifier file :no-error)))
       (let* ((sluggified-title (denote-sluggify title 'title))
              (keywords (denote-retrieve-keywords-value file file-type))
-             (signature (denote-retrieve-filename-signature file))
+             (signature (string-replace "=" " " (denote-retrieve-filename-signature file)))
              (extension (denote-get-file-extension file))
              (dir (file-name-directory file))
              (new-name (denote-format-file-name dir id keywords sluggified-title extension (when signature (denote-sluggify-signature signature)))))

--- a/denote.el
+++ b/denote.el
@@ -2555,7 +2555,7 @@ the changes made to the file: perform them outright."
                  (keywords (denote-keywords-prompt
                             (format "Rename `%s' with keywords (empty to ignore/remove)" file-in-prompt)))
                  (signature (denote-signature-prompt
-                             (denote-retrieve-filename-signature file)
+                             (string-replace "=" " " (denote-retrieve-filename-signature file))
                              (format "Rename `%s' with signature (empty to ignore/remove)" file-in-prompt)))
                  (extension (denote-get-file-extension file))
                  (new-name (denote-format-file-name dir id keywords (denote-sluggify title 'title) extension (denote-sluggify-signature signature))))


### PR DESCRIPTION
When a signature is created and spaces are used, the spaces are converted into `=`s in the function `denote--slug-put-equals`.

When a denote file with a signature is renamed, the signature is presented to the user during the renaming process with all of the `=`s intact.  If the user then accepts the signaturre as-is or changes other parts of the signature but leaves the `=`s in place, the `=`s are then removed by the function `denote--slug-no-punct`, which uses the constant regular expression `denote-excluded-punctuation-regexp`, which includes the `=`.  The resulting new filename is thus missing all `=`s that were in the original, although the user intended them to stay (by not removing them).

This fix simply replaces all `=`s with ` `s (a single space) prior to presenting the signature to the user during the renaming process. The user can then accept the signature as-is, or change any part of it, and the spaces will subsequently be converted into `=`s by `denote--slug-put-equals` and will not be lost.