### PR TITLE
Remove denote-user-enforced-denote-directory

### DIFF
--- a/README.org
+++ b/README.org
@@ -863,7 +863,6 @@ read the video's path when called from there (e.g. by using Emacs'
 
 [[#h:15719799-a5ff-4e9a-9f10-4ca03ef8f6c5][Maintain separate directory silos for notes]].
 
-#+vindex: denote-user-enforced-denote-directory
 There are cases where the user (i) wants to maintain multiple silos
 and (ii) prefers an interactive way to switch between them without
 going through Dired.  Since this is specific to the user's workflow,
@@ -900,7 +899,7 @@ added to the user's Denote configuration:
          (intern (completing-read
                   "Run command in silo: "
                   my-denote-commands-for-silos nil t))))
-  (let ((denote-user-enforced-denote-directory silo))
+  (let ((denote-directory silo))
     (call-interactively command)))
 #+end_src
 
@@ -908,15 +907,12 @@ With this in place, =M-x my-denote-pick-silo-then-command= will use
 minibuffer completion to select a silo among the predefined options
 and then ask for the command to run in that context.
 
-Note the use of the variable ~user-enforced-denote-directory~. This
-variable is specially meant for custom commands to select silos. When
-it is set, it overrides the global default value of ~denote-directory~
-as well as the value provided by the =.dir-locals.el= file. Use it
-only when writing wrapper functions like
-~my-denote-pick-silo-then-command~.
+Note that =let= binding ~denote-directory~ can be used in custom
+commands and other wrapper functions to override the global default
+value of ~denote-directory~ to select silos.
 
-To see another example of a wrapper function that uses
-~user-enforced-denote-directory~, see:
+To see another example of a wrapper function that =let= binds
+~denote-directory~, see:
 
 [[#h:d0c7cb79-21e5-4176-a6af-f4f68578c8dd][Extending Denote: Split an Org subtree into its own note]].
 
@@ -2869,7 +2865,7 @@ Delete the original subtree."
            (heading (org-get-heading :no-tags :no-todo :no-priority :no-comment)))
       (let ((element (org-element-at-point))
             (tags (org-get-tags))
-            (denote-user-enforced-denote-directory silo))
+            (denote-directory silo))
         (delete-region (org-entry-beginning-position)
                        (save-excursion (org-end-of-subtree t) (point)))
         (denote heading
@@ -3829,8 +3825,8 @@ might change them without further notice.
   ~denote-directory~ as a proper directory, also because it accepts a
   directory-local value for what we internally refer to as "silos"
   ([[#h:15719799-a5ff-4e9a-9f10-4ca03ef8f6c5][Maintain separate directories for notes]]).  Custom Lisp code can
-  ~let~ bind the value of the variable ~denote-user-enforced-denote-directory~
-  to override what this function returns.
+  ~let~ bind the value of the variable ~denote-directory~ to override
+  what this function returns.
 
 #+findex: denote-directory-files
 + Function ~denote-directory-files~ :: Return list of absolute file

--- a/denote-journal-extras.el
+++ b/denote-journal-extras.el
@@ -161,7 +161,7 @@ that covered in the documentation of the `denote' function.  It
 is internally processed by `denote-journal-extras--get-date'."
   (interactive (list (when current-prefix-arg (denote-date-prompt))))
   (let ((internal-date (denote-journal-extras--get-date date))
-        (denote-user-enforced-denote-directory (denote-journal-extras-directory)))
+        (denote-directory (denote-journal-extras-directory)))
     (denote
      (denote-journal-extras-daily--title-format internal-date)
      `(,denote-journal-extras-keyword)

--- a/denote-silo-extras.el
+++ b/denote-silo-extras.el
@@ -70,7 +70,7 @@ SILO is a file path from `denote-silo-extras-directories'."
    (list
     (when current-prefix-arg
       (denote-silo-extras--directory-prompt))))
-  (let ((denote-user-enforced-denote-directory silo))
+  (let ((denote-directory silo))
     (call-interactively #'denote)))
 
 ;;;###autoload
@@ -81,7 +81,7 @@ SILO is a file path from `denote-silo-extras-directories'."
    (list
     (when current-prefix-arg
       (denote-silo-extras--directory-prompt))))
-  (let ((denote-user-enforced-denote-directory silo))
+  (let ((denote-directory silo))
     (call-interactively #'denote-open-or-create)))
 
 ;;;###autoload
@@ -93,7 +93,7 @@ COMMAND is one among `denote-silo-extras-commands'."
    (list
     (denote-silo-extras--directory-prompt)
     (denote-command-prompt)))
-  (let ((denote-user-enforced-denote-directory silo))
+  (let ((denote-directory silo))
     (call-interactively command)))
 
 (provide 'denote-silo-extras)

--- a/denote.el
+++ b/denote.el
@@ -585,40 +585,23 @@ things accordingly.")
         `(metadata (category . ,category))
       (complete-with-action action candidates string pred))))
 
-(defun denote--default-directory-is-silo-p ()
-  "Return path to silo if `default-directory' is a silo."
-  (when-let ((dir-locals (dir-locals-find-file default-directory))
-             ((alist-get 'denote-directory dir-local-variables-alist)))
-    (cond
-     ((listp dir-locals)
-      (car dir-locals))
-     ((stringp dir-locals)
-      dir-locals))))
-
 (defun denote--make-denote-directory ()
   "Make the variable `denote-directory' and its parents, if needed."
   (when (not (file-directory-p denote-directory))
     (make-directory denote-directory :parents)))
 
-(defvar denote-user-enforced-denote-directory nil
-  "Value of the variable `denote-directory'.
-Use this to `let' bind a directory path, thus overriding what the
-function `denote-directory' ordinarily returns.")
-
 (defun denote-directory ()
   "Return path of variable `denote-directory' as a proper directory.
-Custom Lisp code can `let' bind the value of the variable
-`denote-user-enforced-denote-directory' to override what this
-function returns.
+Custom Lisp code can `let' bind the variable `denote-directory'
+to override what this function returns."
+  (let ((denote-directory (file-name-as-directory (expand-file-name denote-directory))))
+    (denote--make-denote-directory)
+    denote-directory))
 
-Otherwise, the order of precedence is to first check for a silo
-before falling back to the value of the variable
-`denote-directory'."
-  (let ((path (or denote-user-enforced-denote-directory
-                  (denote--default-directory-is-silo-p)
-                  (denote--make-denote-directory)
-                  (default-value 'denote-directory))))
-    (file-name-as-directory (expand-file-name path))))
+(make-obsolete
+ 'denote-user-enforced-denote-directory
+ 'denote-directory
+ "3.0.0")
 
 (defun denote--slug-no-punct (str &optional extra-characters)
   "Remove punctuation from STR.

--- a/tests/denote-test.el
+++ b/tests/denote-test.el
@@ -31,16 +31,6 @@
 (require 'ert)
 (require 'denote)
 
-;; TODO 2023-05-22: Incorporate an actual silo in this test directory
-;; and modify the test accordingly.
-(ert-deftest denote-test-denote--default-directory-is-silo-p ()
-  "Test that `denote--default-directory-is-silo-p' returns a path."
-  (let ((path (denote--default-directory-is-silo-p)))
-    (should (or (null path)
-                (and (stringp path)
-                     (file-exists-p path)
-                     (file-directory-p path))))))
-
 (ert-deftest denote-test--denote--make-denote-directory ()
   "Test that `denote--make-denote-directory' creates the directory."
   (should (null (denote--make-denote-directory))))


### PR DESCRIPTION
[Ready to be merged.]

Ignore this pull request if I have missed some use-case.

I have looked in the manual because I wanted to understand
`denote-user-enforced-denote-directory`. It seems like users are meant
to let-bind it to enforce a specific value for `denote-directory`.
However, after some tests, let-binding `denote-directory` directly also
works.

I have removed this user-option in this pull request and adapted the
manual accordingly.