### PR TITLE
New variable `denote-link-description-function` and some bug fixes

### DIFF
--- a/denote.el
+++ b/denote.el
@@ -1811,14 +1811,68 @@ increment it 1 second at a time until an available id is found."
 
 ;;;;; The `denote' command and its prompts
 
-(defvar denote--use-region-in-denote-command t
-  "If non-nil, the region can be used by the `denote' command.
+(defvar denote-ignore-region-in-denote-command nil
+  "If non-nil, the region is ignored by the `denote' command.
 
 The `denote' command uses the region as the default title when
-prompted for a title.  When this variable is nil, the `denote'
-command ignores the region.  This variable is meant to be used in
-commands such as `denote-region' which have their own way of
-handling the region.")
+prompted for a title.  When this variable is non-nil, the
+`denote' command ignores the region.  This variable is useful in
+commands that have their own way of handling the region.")
+
+;; NOTE 2024-01-13: This is a candidate for a user option.
+(defvar denote-save-buffer-after-creation nil
+  "If non-nil, the buffer is saved at the end of the `denote' command.")
+
+(defvar denote-title-prompt-current-default nil
+  "Currently bound default title for `denote-title-prompt'.
+Set the value of this variable within the lexical scope of a
+command that needs to supply a default title before calling
+`denote-title-prompt'.")
+
+(defun denote--command-with-features (command force-use-file-prompt-as-default-title force-ignore-region force-save in-background)
+  "Execute file-creating COMMAND with specified features.
+
+COMMAND is the symbol of a file-creating command to call, such as
+`denote' or `denote-signature'.
+
+With non-nil FORCE-USE-FILE-PROMPT-AS-DEFAULT-TITLE, use the last
+item of `denote-file-history' as the default title of the title
+prompt.  This is useful in a command such as `denote-link' where
+the entry of the file prompt can be reused as the default title.
+
+With non-nil FORCE-IGNORE-REGION, the region is ignore when
+creating the note, i.e. it will not be used as the initial title
+in a title prompt.  Else, the value of
+`denote-ignore-region-in-denote-command' is respected.
+
+With non-nil FORCE-SAVE, the file is saved at the end of the note
+creation.  Else, the value of `denote-save-buffer-after-creation'
+is respected.
+
+With non-nil IN-BACKGROUND, the note creation happens in the
+background, i.e. the note's buffer will not be displayed after
+the note is created.
+
+Note that if all parameters except COMMAND are nil, this is
+equivalent to `(call-interactively command)'.
+
+The path of the newly created file is returned."
+  (let ((denote-save-buffer-after-creation
+         (or force-save denote-save-buffer-after-creation))
+        (denote-ignore-region-in-denote-command
+         (or force-ignore-region denote-ignore-region-in-denote-command))
+        (denote-title-prompt-current-default
+         (if force-use-file-prompt-as-default-title
+             (when denote--file-history (pop denote--file-history))
+           denote-title-prompt-current-default))
+        (path))
+    (if in-background
+        (save-window-excursion
+          (call-interactively command)
+          (setq path (buffer-file-name)))
+      (call-interactively command)
+      (setq path (buffer-file-name)))
+    path))
 
 ;;;###autoload
 (defun denote (&optional title keywords file-type subdirectory date template signature)
@@ -1858,7 +1912,7 @@ When called from Lisp, all arguments are optional.
      (dolist (prompt denote-prompts)
        (pcase prompt
          ('title (aset args 0 (denote-title-prompt
-                               (when (and denote--use-region-in-denote-command
+                               (when (and (not denote-ignore-region-in-denote-command)
                                           (use-region-p))
                                  (buffer-substring-no-properties
                                   (region-beginning)
@@ -1887,17 +1941,12 @@ When called from Lisp, all arguments are optional.
                      (or (alist-get template denote-templates) "")))
          (signature (or signature "")))
     (denote--prepare-note title kws date id directory file-type template signature)
+    (when denote-save-buffer-after-creation (save-buffer))
     (denote--keywords-add-to-history keywords)
     (run-hooks 'denote-after-new-note-hook)))
 
 (defvar denote--title-history nil
   "Minibuffer history of `denote-title-prompt'.")
-
-(defvar denote-title-prompt-current-default nil
-  "Currently bound default title for `denote-title-prompt'.
-Set the value of this variable within the lexical scope of a
-command that needs to supply a default title before calling
-`denote-title-prompt'.")
 
 (defun denote-title-prompt (&optional default-title prompt-text)
   "Prompt for title string.
@@ -2139,7 +2188,7 @@ is set to \\='(signature title keywords)."
            ;; the moment `insert' is called.
            (text (buffer-substring-no-properties (region-beginning) (region-end))))
       (progn
-        (let ((denote--use-region-in-denote-command nil))
+        (let ((denote-ignore-region-in-denote-command t))
           (call-interactively 'denote))
         (push-mark (point))
         (insert text)


### PR DESCRIPTION
I have added the user option `denote-link-description-function` (as a
defvar for now) which defaults to display the signature (if present) and
the title. I think it is a good default, but we can change it. It is now
easy to configure the link descriptions to look like:
  - "Link"
  - "20240101T111111--My-note.org"
  - "My file title"
  - "My file title (keyword1, keyword2)"
  - "sig1z3   My other title"  (the default if signature is present)
  - "My other title (sig1z3)"
  - A prompt for the description
  - etc.

`denote-link-description-function` can be `let` bound if we want to fix
the description format in specific functions, but we should avoid doing
that and let the user decide most of the time. The user can also let
bind this variable if he wants to change the behavior for a specific
command.

Some comments:

- `denote-link-after-creating-with-command` previously displayed the
  signature in the description if it were specifically called with a
  command named `denote-signature`. This was not robust because a user
  can create any command that is not named `denote-signature` that still
  includes the signature prompt. In this case, he would not get the
  signature in the link's description. I have made it obey
  `denote-link-description-function` instead. The current default will
  display the signature if there is one, so the behavior is not changed.
  It can now be configured.
- Similarly, `denote-add-links`, `denote-org-dblock--get-file-contents`
  and `denote-link-with-signature` obey
  `denote-link-description-function`. With the default value, it is the
  same behavior as before.

Bugs fixed:

  - This bug has been reported on the mailing list for
    `denote-link-or-create`, but any command that made use of the
    `denote--link-after-creating-subr` (all commands except
    `denote-link`) used the file-type of the linked file instead of that
    of the current file. This is fixed.
  - `denote-link-or-create`, when called with an active region and the
    file does not exist yet, would use the active region as the initial
    title prompt (in addition to the default prompt being what was typed
    in the `denote-file-prompt`). This looks strange, so I have fixed it
    using `denote--command-with-features`. The region should only be
    used as the description text here and not the title prompt.

The rest is just cleanup and refactoring. It is ready to be merged.