### PR TITLE
Fix denote-link-description-with-signature-and-title

### DIFF
--- a/README.org
+++ b/README.org
@@ -1745,11 +1745,12 @@ When ~denote-link~ is called with a prefix argument (=C-u= by
 default), it formats links like =[[denote:IDENTIFIER]]=.  The user
 might prefer its simplicity.
 
-The description of the link is taken from the target file's front
-matter or, if that is not available, from the file name.  If the
-region is active, its text is used as the link's description instead.
-If the active region has no text, the inserted link uses just the
-identifier, as with the =C-u= prefix mentioned above.
+By default, the description of the link is taken from the signature of
+the file, if present, and the target file's front matter's title or, if
+that is not available, from the file name.  If the region is active, its
+text is used as the link's description instead.  If the active region
+has no text, the inserted link uses just the identifier, as with the
+=C-u= prefix mentioned above.
 
 Inserted links are automatically buttonized and remain active for as
 long as the buffer is available.  In Org this is handled by the major

--- a/denote.el
+++ b/denote.el
@@ -666,6 +666,14 @@ leading and trailing hyphen."
     "-\\{2,\\}" "-"
     (replace-regexp-in-string "_\\|\s+" "-" str))))
 
+(defun denote--remove-dot-characters (str)
+  "Remove the dot character from STR."
+  (replace-regexp-in-string "\\." "" str))
+
+(defun denote--trim-right-token-characters (str)
+  "Remove =, - and _ from the end of STR."
+  (string-trim-right str "=-_"))
+
 (defun denote--replace-consecutive-token-characters (str)
   "Replace consecutive characters with a single one in STR.
 Spaces, underscores and equal signs are replaced with a single
@@ -695,7 +703,9 @@ used as the keywords separator in file names."
                            (funcall (or slug-function #'denote-sluggify-keyword) str)))
                          ((eq component 'signature)
                           (funcall (or slug-function #'denote-sluggify-signature) str)))))
-    (denote--replace-consecutive-token-characters str-slug)))
+    (denote--trim-right-token-characters
+     (denote--replace-consecutive-token-characters
+      (denote--remove-dot-characters str-slug)))))
 
 (make-obsolete
  'denote-letter-case

--- a/denote.el
+++ b/denote.el
@@ -3204,16 +3204,16 @@ file is returned as the description.")
 (defun denote-link-description-with-signature-and-title (file region-text)
   "Return description from FILE as \"signature   title\".
 
-If REGION-TEXT is not empty (or nil), the description is the text
-of the active region instead.
+If REGION-TEXT is non-nil, the description is the text of the
+active region instead.
 
 The format is specified in variable
-`denote--link-signature-format'. If a signature is not present,
+`denote--link-signature-format'.  If a signature is not present,
 only the title is returned."
   (let* ((file-type (denote-filetype-heuristics file))
          (signature (denote-retrieve-filename-signature file))
          (title (denote--retrieve-title-or-filename file file-type)))
-    (cond ((and region-text (not (string-empty-p region-text)))
+    (cond (region-text
            region-text)
           (signature
            (format denote--link-signature-format signature title))
@@ -3257,7 +3257,10 @@ With optional ID-ONLY as a non-nil argument, such as with a
 universal prefix (\\[universal-argument]), insert links with just
 the identifier and no further description.  In this case, the
 link format is always [[denote:IDENTIFIER]].  If the DESCRIPTION
-is empty, the link is also as if ID-ONLY were non-nil.
+is empty, the link is also as if ID-ONLY were non-nil.  The
+default value of `denote-link-description-function' returns an
+empty string when the region is empty.  Thus, the link will have
+no description in this case.
 
 When called from Lisp, FILE is a string representing a full file
 system path.  FILE-TYPE is a symbol as described in


### PR DESCRIPTION
In the docstring of `denote-link`, it was said that an empty region
leads to links of type `id-only`. I forgot to make this work also in the
new code. This commit fixes that. Note that this works because the
default `denote-link-description-with-signature-and-title` decides to
return an empty string when given an empty region. This can behave
differently if the option is set to another function, which is ok.