### PR TITLE
Various fixes

### DIFF
--- a/README.org
+++ b/README.org
@@ -1820,8 +1820,8 @@ The ~denote-link~ command inserts a link at point to a file specified
 at the minibuffer prompt ([[#h:d99de1fb-b1b7-4a74-8667-575636a4d6a4][The ~denote-org-store-link-to-heading~ user option]]).
 Links are formatted depending on the file type of the current note. In
 Org and plain text buffers, links are formatted thus:
-=[[denote:IDENTIFIER][TITLE]]=. While in Markdown they are expressed
-as =[TITLE](denote:IDENTIFIER)=.
+=[[denote:IDENTIFIER][DESCRIPTION]]=. While in Markdown they are expressed
+as =[DESCRIPTION](denote:IDENTIFIER)=.
 
 When ~denote-link~ is called with a prefix argument (=C-u= by
 default), it formats links like =[[denote:IDENTIFIER]]=.  The user
@@ -1920,7 +1920,7 @@ As part of the optional =denote-org-extras.el= extension, the command
 ~denote-org-extras-link-to-heading~ prompts for a link to an Org file
 and then asks for a heading therein, using minibuffer completion. Once
 the user provides input at the two prompts, the command inserts a link
-at point which has the following pattern: =[[denote:IDENTIFIER::#ORG-HEADING-CUSTOM-ID]][File title::Heading text]]=.
+at point which has the following pattern: =[[denote:IDENTIFIER::#ORG-HEADING-CUSTOM-ID]][Description::Heading text]]=.
 
 Because only Org files can have links to individual headings, the
 command ~denote-org-extras-link-to-heading~ prompts only for Org files

--- a/denote-org-extras.el
+++ b/denote-org-extras.el
@@ -284,13 +284,9 @@ argument."
          (format "- %s\n\n"
                  (denote-format-link
                   file
-                  (if (eq add-links 'id-only)
-                      denote-id-only-link-format
-                    denote-org-link-format)
-                  (let ((type (denote-filetype-heuristics file)))
-                    (if (denote-file-has-signature-p file)
-                        (denote--link-get-description-with-signature file type)
-                      (denote--link-get-description file type)))))))
+                  (denote--link-get-description file)
+                  'org
+                  (eq add-links 'id-only)))))
       (let ((beginning-of-contents (point)))
         (insert-file-contents file)
         (when no-front-matter

--- a/denote-org-extras.el
+++ b/denote-org-extras.el
@@ -77,10 +77,7 @@ the current file."
       (cons (denote-link-ol-get-heading) (denote-link-ol-get-id)))))
 
 (defun denote-org-extras-format-link-with-heading (file heading-id description)
-  "Prepare link to FILE with HEADING-ID using DESCRIPTION.
-
-FILE-TYPE and ID-ONLY are used to get the format of the link.
-See the `:link' property of `denote-file-types'."
+  "Prepare link to FILE with HEADING-ID using DESCRIPTION."
   (format "[[denote:%s::#%s][%s]]"
           (denote-retrieve-filename-identifier file)
           heading-id
@@ -92,7 +89,7 @@ See the `:link' property of `denote-file-types'."
 
 The resulting link has the following pattern:
 
-[[denote:IDENTIFIER::#ORG-HEADING-CUSTOM-ID]][File title::Heading text]].
+[[denote:IDENTIFIER::#ORG-HEADING-CUSTOM-ID]][Description::Heading text]].
 
 Because only Org files can have links to individual headings,
 limit the list of possible files to those which include the .org

--- a/denote.el
+++ b/denote.el
@@ -4118,17 +4118,16 @@ create a new one."
 Also see the user option `denote-org-store-link-to-heading'."
   (when-let ((file (buffer-file-name))
              ((denote-file-is-note-p file))
-             (file-type (denote-filetype-heuristics file))
              (file-id (denote-retrieve-filename-identifier file))
-             (file-title (denote--link-get-description file)))
+             (description (denote--link-get-description file)))
     (let ((heading-links (and denote-org-store-link-to-heading (derived-mode-p 'org-mode))))
       (org-link-store-props
        :type "denote"
        :description (if heading-links
                         (denote-link-format-heading-description
-                         (denote--link-get-description file)
+                         description
                          (denote-link-ol-get-heading))
-                      file-title)
+                      description)
        :link (if heading-links
                  (format "denote:%s::#%s" file-id (denote-link-ol-get-id))
                (concat "denote:" file-id)))

--- a/denote.el
+++ b/denote.el
@@ -1798,7 +1798,7 @@ TEMPLATE, and SIGNATURE should be valid for note creation."
          (buffer (find-file path))
          (header (denote--format-front-matter
                   title (denote--date date file-type) keywords
-                  (format-time-string denote-id-format date)
+                  id
                   file-type)))
     (with-current-buffer buffer
       (insert header)
@@ -1845,15 +1845,15 @@ where the former does not read dates without a time component."
 (defun denote-parse-date (date)
   "Return DATE as an appropriate value for the `denote' command.
 
-- If DATE is a list, assume it is consistent with `current-date'
-  or related and return it as-is.
+- If DATE is non-nil and a list, assume it is consistent with
+  `current-date' or related and return it as-is.
 
 - If DATE is a non-empty string, try to convert it with
   `date-to-time'.
 
 - If DATE is none of the above, return `current-time'."
   (cond
-   ((listp date)
+   ((and date (listp date))
     date)
    ((and (stringp date) (not (string-empty-p date)))
     (denote--valid-date date))

--- a/denote.el
+++ b/denote.el
@@ -1136,13 +1136,11 @@ the keywords component of a Denote file name.  STRING is the same
 as the return value of `denote-retrieve-filename-keywords'."
   (string-join (split-string string "_" :omit-nulls "_") ","))
 
-(define-obsolete-variable-alias
-  'denote--keyword-history
-  'denote-keyword-history
-  "3.0.0")
-
 (defvar denote-keyword-history nil
   "Minibuffer history of inputted keywords.")
+
+(defalias 'denote--keyword-history 'denote-keyword-history
+  "Compatibility alias for `denote-keyword-history'.")
 
 (defun denote--keywords-crm (keywords &optional prompt initial)
   "Use `completing-read-multiple' for KEYWORDS.


### PR DESCRIPTION
Fixes:

- Fix `denote-org-extras-dblock--get-file-contents`, as reported in
  #224.

- Make `denote--keyword-history` an alias of `denote-keyword-history.

- Fix issue #230.

- Update some docstrings and README.org about link descriptions.