### PR TITLE
Fix: Consider the CLOSED property of the org-heading for heading-date

### DIFF
--- a/denote-org-extras.el
+++ b/denote-org-extras.el
@@ -122,10 +122,18 @@ To only link to a file, use the `denote-link' command."
 (defun denote-org-extras--get-heading-date ()
   "Try to return a timestamp for the current Org heading.
 This can be used as the value for the DATE argument of the
-`denote' command."
+`denote' command.
+
+If the heading includes a DATE or CREATED or CLOSED property with
+a timestamp value, use that to derive the date (or date and time)
+of the new note (if there is only a date, the time is taken as
+00:00). If more than one of these properties is present, the
+order of preference is DATE, followed by CREATED, followed by
+CLOSED."
   (when-let ((pos (point))
              (timestamp (or (org-entry-get pos "DATE")
-                            (org-entry-get pos "CREATED"))))
+                            (org-entry-get pos "CREATED")
+                            (org-entry-get pos "CLOSED"))))
     (date-to-time timestamp)))
 
 ;;;###autoload
@@ -140,12 +148,12 @@ the title of the new note.
 If the heading has any tags, use them as the keywords of the new
 note.  Else do not include any keywords.
 
-If the subtree has a PROPERTIES drawer, retain it for further
-review.  If the PROPERTIES drawer includes a DATE or CREATED
-property with a timestamp value, use that to derive the date (or
-date and time) of the new note (if there is only a date, the time
-is taken as 00:00).  If both DATE and CREATED properties are
-present, the former is used.
+If the heading has a date associated with it, use it as the date
+of the new note. See `denote-org-extras--get-heading-date' for
+details on how we look for a date.
+
+If the heading has a PROPERTIES drawer, retain it for further
+review.
 
 Make the new note an Org file regardless of the value of
 `denote-file-type'."


### PR DESCRIPTION
This property is automatically added to a task when we mark it as DONE. If both DATE as well as CREATED are not available, this is a valuable property to use when determining the date of the new note.