### PR TITLE
Use denote-prompts to prompt user when extracting org subtree

### DIFF
--- a/denote-org-extras.el
+++ b/denote-org-extras.el
@@ -161,10 +161,19 @@ Make the new note an Org file regardless of the value of
   (if-let ((text (org-get-entry))
            (heading (denote-link-ol-get-heading)))
       (let ((tags (org-get-tags))
-            (date (denote-org-extras--get-heading-date)))
+            (date (denote-org-extras--get-heading-date))
+            subdirectory
+            signature)
+        (dolist (prompt denote-prompts)
+          (pcase prompt
+            ('keywords (when (not tags)
+                         (setq tags (denote-keywords-prompt))))
+            ('subdirectory (setq subdirectory (denote-subdirectory-prompt)))
+            ('date (when (not date) (setq date (denote-date-prompt))))
+            ('signature (setq signature (denote-signature-prompt)))))
         (delete-region (org-entry-beginning-position)
                        (save-excursion (org-end-of-subtree t) (point)))
-        (denote heading tags 'org nil date)
+        (denote heading tags 'org subdirectory date nil signature)
         (insert text))
     (user-error "No subtree to extract; aborting")))
 


### PR DESCRIPTION
This requirement might be specific to my workflow and I would love maintainer feedback about it.

1. denote-subdirectory-prompt: When I am extracting data from my org-files as Denote notes, I _almost never_ want them to end up in the default directory. Instead, I want them to go to different directories based on the kind of content I am extracting.

2. denote-signature-prompt: I use signatures to track trails of thought, and as such I use them for certain kinds of notes. I'd like this data to be converted properly to Denote when I move from subtree-based notes to Denote notes.