### PR TITLE
Remove denote-user-enforced-denote-directory

### DIFF
--- a/README.org
+++ b/README.org
@@ -813,7 +813,7 @@ file, with the following contents:
 ;;;
 ;;;     (info "(emacs) Directory Variables")
 
-((nil . ((denote-directory . default-directory))))
+((nil . ((denote-directory . "/path/to/silo/"))))
 #+end_src
 
 When inside the directory that contains this =.dir-locals.el= file, all
@@ -859,7 +859,7 @@ silo-specific value.  For example, this one changes the
 ;;;
 ;;;     (info "(emacs) Directory Variables")
 
-((nil . ((denote-directory . default-directory)
+((nil . ((denote-directory . "/path/to/silo/")
          (denote-known-keywords . ("food" "drink")))))
 #+end_src
 
@@ -870,7 +870,7 @@ This one is like the above, but also disables ~denote-infer-keywords~:
 ;;;
 ;;;     (info "(emacs) Directory Variables")
 
-((nil . ((denote-directory . default-directory)
+((nil . ((denote-directory . "/path/to/silo/")
          (denote-known-keywords . ("food" "drink"))
          (denote-infer-keywords . nil))))
 #+end_src
@@ -883,30 +883,12 @@ modes, we can do something like this:
 ;;;
 ;;;     (info "(emacs) Directory Variables")
 
-((nil . ((denote-directory . default-directory)
+((nil . ((denote-directory . "/path/to/silo/")
          (denote-known-keywords . ("food" "drink"))
          (denote-infer-keywords . nil)))
  (org-mode . ((org-hide-emphasis-markers . t)
               (org-hide-macro-markers . t)
               (org-hide-leading-stars . t))))
-#+end_src
-
-IMPORTANT If your silo contains sub-directories of notes, you
-should replace ~default-directory~ in the above examples with an
-absolute path to your silo directory, otherwise links from files
-within the sub-directories cannot be made to files in the parent
-directory. For example:
-
-#+begin_src emacs-lisp
-;;; Directory Local Variables.  For more information evaluate:
-;;;
-;;;     (info "(emacs) Directory Variables")
-  ((nil . ((denote-directory . "~/my-silo")
-           (denote-known-keywords . ("food" "drink"))
-           (denote-infer-keywords . nil)))
-   (org-mode . ((org-hide-emphasis-markers . t)
-                (org-hide-macro-markers . t)
-                (org-hide-leading-stars . t))))
 #+end_src
 
 As not all user options have a "safe" local value, Emacs will ask the
@@ -943,7 +925,6 @@ read the video's path when called from there (e.g. by using Emacs'
 
 [[#h:15719799-a5ff-4e9a-9f10-4ca03ef8f6c5][Maintain separate directory silos for notes]].
 
-#+vindex: denote-user-enforced-denote-directory
 There are cases where the user (i) wants to maintain multiple silos
 and (ii) prefers an interactive way to switch between them without
 going through Dired.  Since this is specific to the user's workflow,
@@ -980,7 +961,7 @@ added to the user's Denote configuration:
          (intern (completing-read
                   "Run command in silo: "
                   my-denote-commands-for-silos nil t))))
-  (let ((denote-user-enforced-denote-directory silo))
+  (let ((denote-directory silo))
     (call-interactively command)))
 #+end_src
 
@@ -988,15 +969,12 @@ With this in place, =M-x my-denote-pick-silo-then-command= will use
 minibuffer completion to select a silo among the predefined options
 and then ask for the command to run in that context.
 
-Note the use of the variable ~user-enforced-denote-directory~. This
-variable is specially meant for custom commands to select silos. When
-it is set, it overrides the global default value of ~denote-directory~
-as well as the value provided by the =.dir-locals.el= file. Use it
-only when writing wrapper functions like
-~my-denote-pick-silo-then-command~.
+Note that =let= binding ~denote-directory~ can be used in custom
+commands and other wrapper functions to override the global default
+value of ~denote-directory~ to select silos.
 
-To see another example of a wrapper function that uses
-~user-enforced-denote-directory~, see:
+To see another example of a wrapper function that =let= binds
+~denote-directory~, see:
 
 [[#h:d0c7cb79-21e5-4176-a6af-f4f68578c8dd][Extending Denote: Split an Org subtree into its own note]].
 
@@ -3917,7 +3895,7 @@ might change them without further notice.
   ~denote-directory~ as a proper directory, also because it accepts a
   directory-local value for what we internally refer to as "silos"
   ([[#h:15719799-a5ff-4e9a-9f10-4ca03ef8f6c5][Maintain separate directories for notes]]).  Custom Lisp code can
-  ~let~ bind the value of the variable ~denote-user-enforced-denote-directory~
+  ~let~ bind the value of the variable ~denote-directory~
   to override what this function returns.
 
 #+findex: denote-directory-files

--- a/denote-journal-extras.el
+++ b/denote-journal-extras.el
@@ -160,7 +160,7 @@ that covered in the documentation of the `denote' function.  It
 is internally processed by `denote-journal-extras--get-date'."
   (interactive (list (when current-prefix-arg (denote-date-prompt))))
   (let ((internal-date (denote-journal-extras--get-date date))
-        (denote-user-enforced-denote-directory (denote-journal-extras-directory)))
+        (denote-directory (denote-journal-extras-directory)))
     (denote
      (denote-journal-extras-daily--title-format internal-date)
      `(,denote-journal-extras-keyword)

--- a/denote-silo-extras.el
+++ b/denote-silo-extras.el
@@ -71,7 +71,7 @@ SILO is a file path from `denote-silo-extras-directories'.
 
 When called from Lisp, SILO is a file system path to a directory."
   (interactive (list (denote-silo-extras--directory-prompt)))
-  (let ((denote-user-enforced-denote-directory silo))
+  (let ((denote-directory silo))
     (call-interactively #'denote)))
 
 ;;;###autoload
@@ -81,7 +81,7 @@ SILO is a file path from `denote-silo-extras-directories'.
 
 When called from Lisp, SILO is a file system path to a directory."
   (interactive (list (denote-silo-extras--directory-prompt)))
-  (let ((denote-user-enforced-denote-directory silo))
+  (let ((denote-directory silo))
     (call-interactively #'denote-open-or-create)))
 
 ;;;###autoload
@@ -95,7 +95,7 @@ When called from Lisp, SILO is a file system path to a directory."
    (list
     (denote-silo-extras--directory-prompt)
     (denote-command-prompt)))
-  (let ((denote-user-enforced-denote-directory silo))
+  (let ((denote-directory silo))
     (call-interactively command)))
 
 (provide 'denote-silo-extras)

--- a/denote.el
+++ b/denote.el
@@ -123,6 +123,11 @@
 
 ;; About the autoload: (info "(elisp) File Local Variables")
 
+(define-obsolete-variable-alias
+ 'denote-user-enforced-denote-directory
+ 'denote-directory
+ "3.0.0")
+
 ;;;###autoload (put 'denote-directory 'safe-local-variable (lambda (val) (or (stringp val) (eq val 'local) (eq val 'default-directory))))
 (defcustom denote-directory (expand-file-name "~/Documents/notes/")
   "Directory for storing personal notes.
@@ -655,11 +660,6 @@ to override what this function returns."
     (let ((denote-directory (file-name-as-directory (expand-file-name denote-directory))))
       (denote--make-denote-directory)
       denote-directory)))
-
-(make-obsolete
- 'denote-user-enforced-denote-directory
- 'denote-directory
- "3.0.0")
 
 (defun denote--slug-no-punct (str &optional extra-characters)
   "Remove punctuation from STR.

--- a/tests/denote-test.el
+++ b/tests/denote-test.el
@@ -31,16 +31,6 @@
 (require 'ert)
 (require 'denote)
 
-;; TODO 2023-05-22: Incorporate an actual silo in this test directory
-;; and modify the test accordingly.
-(ert-deftest denote-test-denote--default-directory-is-silo-p ()
-  "Test that `denote--default-directory-is-silo-p' returns a path."
-  (let ((path (denote--default-directory-is-silo-p)))
-    (should (or (null path)
-                (and (stringp path)
-                     (file-exists-p path)
-                     (file-directory-p path))))))
-
 (ert-deftest denote-test--denote--make-denote-directory ()
   "Test that `denote--make-denote-directory' creates the directory."
   (should (null (denote--make-denote-directory))))


### PR DESCRIPTION
This is my second attempt at removing this user option. Let binding
`denote-directory` directly should work.

The first time, I overlooked the way of setting `denote-directory` to
`default-directory` or `local` in `.dir-locals.el` and it broke some
user setup. I was doing some tests, but I was experiencing issues when I
tried to put `.dir-locals.el` in subdirectories. Apparently, they do not
stack. Only the closest `.dir-locals.el` is used. This is an issue I had
even with the actual code. It was just a misunderstanding on my part.

Let-binding `denote-directory` should be enough and we don't need the
user option `denote-user-enforced-denote-directory`. However, I think we
really should always set `denote-directory` to a path string, even in
`.dir-locals.el`. I have updated the manual accordingly. However, I
still support these special values to not break current user's config.
We might want to mention in the release notes that it could be removed
eventually.

This old behavior is retained: If `denote-directory` is the symbol
`default-directory` (or `local`), we can assume it was set in a
`.dir-locals.el` as previously specified in the manual.

We can also remove it right away if you want. We don't really need a
shortcut for a setting in `.dir-locals.el` since this is a one-time setup.
The manual already does not mention this possibility anymore. Let me
know if you would like this instead.