### PR TITLE
Kill "hidden" buffer generated by `denote-link-return-links`

### DIFF
--- a/denote.el
+++ b/denote.el
@@ -3506,7 +3506,8 @@ Also see `denote-link-return-backlinks'."
              ((denote-file-has-supported-extension-p current-file))
              (file-type (denote-filetype-heuristics current-file))
              (regexp (denote--link-in-context-regexp file-type)))
-    (with-current-buffer (find-file-noselect current-file)
+    (with-temp-buffer
+      (insert-file-contents current-file)
       (denote-link--expand-identifiers regexp))))
 
 (defalias 'denote-link-return-forelinks 'denote-link-return-links


### PR DESCRIPTION
Hi! As suggested in #251, I implemented the change to `denote-link-return-links`. 

With this change, `denote-link-return-links` will avoid keeping visited buffers open.