### PR TITLE
Fix condition in denote-parse-date 

### DIFF
--- a/denote.el
+++ b/denote.el
@@ -1899,7 +1899,7 @@ If DATE is nil, return nil."
   "Return DATE as an appropriate value for the `denote' command.
 Pass DATE through `denote-valid-date-p' and use its return value.
 If either that or DATE is nil, return `current-time'."
-  (or (denote-valid-date-p date)) (current-time))
+  (or (denote-valid-date-p date) (current-time)))
 
 (defun denote--buffer-file-names ()
   "Return file names of Denote buffers."


### PR DESCRIPTION
Hi,
when using `denote-org-extras-extract-org-subtree` I found that `id` and `date` of the extracted note are always with current date (but `DATE` or `CREATED` properties were present in the original heading).
The rootcause is probably typo in the condition at the end of `denote-parse-date`.