### PR TITLE
Fix edge-cases when inserting missing links via org-dblock

### DIFF
--- a/denote-org-extras.el
+++ b/denote-org-extras.el
@@ -232,11 +232,12 @@ Also see `denote-org-extras-dblock--files-missing-only'."
   "Return list of missing links to all notes matching REGEXP.
 Missing links are those for which REGEXP does not have a match in
 the current buffer."
-  (if-let ((found-files (denote-directory-files regexp :omit-current))
-           (linked-files (denote-link--expand-identifiers denote-org-link-in-context-regexp))
-           (final-files (seq-difference found-files linked-files)))
-      final-files
-    (message "All links matching `%s' are present" regexp)))
+  (let ((found-files (denote-directory-files regexp :omit-current))
+        (linked-files (denote-link--expand-identifiers denote-org-link-in-context-regexp)))
+    (if-let ((final-files (seq-difference found-files linked-files)))
+        final-files
+      (message "All links matching `%s' are present" regexp)
+      '())))
 
 (defun denote-org-extras-dblock--files-missing-only (files-matching-regexp &optional sort-by-component reverse)
   "Return list of missing links to FILES-MATCHING-REGEXP.


### PR DESCRIPTION
To reproduce the problem: open a new note and while it is empty, try to insert and populate an org dblock of type "denote-missing-links".

This leads to the following stack-trace:

```
Debugger entered--Lisp error: (wrong-type-argument stringp 65)
  file-name-nondirectory(65)
  file-name-extension(65 :period)
  denote-get-file-extension(65)
  denote-get-file-extension-sans-encryption(65)
  denote-filetype-heuristics(65)
  denote-link-description-with-signature-and-title(65 nil)
  denote--link-get-description(65)
  #f(compiled-function (file) #<bytecode -0x3aa12408d80ef11>)(65)
  mapc(#f(compiled-function (file) #<bytecode -0x3aa12408d80ef11>) "All links matching ‘reference/2024012’ are present")
  denote-link--prepare-links("All links matching ‘reference/2024012’ are present" org nil :no-other-sorting)
  denote-link--insert-links("All links matching ‘reference/2024012’ are present" org nil :no-other-sorting)
  org-dblock-write:denote-missing-links((:name "denote-missing-links" :regexp "reference/2024012" :indentation-column 0 :content #("\n" 0 1 (org-fold-core-fontified t fontified t))))
```

There are two issues in the underlying code:

1. When `denote-org-extras-dblock--get-missing-links` finds 0 missing-links, it returns with a string (return value of `message`) instead of with an empty list.

2. When there are 0 pre-existing denote links in the current buffer, `(denote-link--expand-identifiers
denote-org-link-in-context-regexp)` returns nil. This sets `linked-files` value to `nil` and short-circuits the `if-let` when it should not.

This commit fixes these two issues.