### PR TITLE
Make denote-link-description-function require a function with only one argument

### DIFF
--- a/README.org
+++ b/README.org
@@ -4563,12 +4563,12 @@ might change them without further notice.
 
 #+findex: denote-link-description-with-signature-and-title
 + Function ~denote-link-description-with-signature-and-title~ :: Return
-  link description for =FILE=. With optional =REGION-TEXT= as a
-  string, make that the description. Otherwise, produce a description
-  as follows:
+  link description for =FILE=.  Produce a description as follows:
+
+- If the region is active, use it as the description.
 
 - If =FILE= as a signature, then use the
-  ~denote-link-signature-format~. By default, this looks like
+  ~denote-link-signature-format~.  By default, this looks like
   "signature title".
 
 - If =FILE= does not have a signature, then use its title as the

--- a/denote.el
+++ b/denote.el
@@ -3445,14 +3445,12 @@ file is returned as the description.")
   "Return link description for FILE."
   (funcall
    (or denote-link-description-function #'denote-link-description-with-signature-and-title)
-   file
-   (denote--get-active-region-content)))
+   file))
 
-(defun denote-link-description-with-signature-and-title (file &optional region-text)
+(defun denote-link-description-with-signature-and-title (file)
   "Return link description for FILE.
 
-With optional REGION-TEXT as a string, make that the description.
-Otherwise, produce a description as follows:
+- If the region is active, use it as the description.
 
 - If FILE as a signature, then use the `denote-link-signature-format'.
   By default, this looks like \"signature   title\".
@@ -3461,7 +3459,8 @@ Otherwise, produce a description as follows:
   description."
   (let* ((file-type (denote-filetype-heuristics file))
          (signature (denote-retrieve-filename-signature file))
-         (title (denote--retrieve-title-or-filename file file-type)))
+         (title (denote--retrieve-title-or-filename file file-type))
+         (region-text (denote--get-active-region-content)))
     (cond (region-text
            region-text)
           (signature


### PR DESCRIPTION
I have checked the documentation you made about
`denote-link-description-function`. There is a difference between what
is documented and the implementation. The current code requires that
`denote-link-description-function` be a function that takes two
parameters instead of only one. However, what you have documented is
better than what is implemented.

In this pull request, I removed this second parameter. It really is
unnecessary and may be confusing.

Since the functionality has not been released in an official version, it
does not seem to late to fix it.