### PR TITLE
rename-buffer: really retrieve keywords for non-text files

### DIFF
--- a/denote-rename-buffer.el
+++ b/denote-rename-buffer.el
@@ -100,10 +100,9 @@ buffer will be used, if available."
                         (cons ?i (or (denote-retrieve-filename-identifier file) ""))
                         (cons ?d (or (denote-retrieve-filename-identifier file) ""))
                         (cons ?s (or (denote-retrieve-filename-signature file) ""))
-                        (cons ?k (cond
-                                  ((denote-retrieve-front-matter-keywords-value-as-string file type))
-                                  ((denote-retrieve-filename-keywords file))
-                                  (t  "")))
+                        (cons ?k (if-let ((kws (denote-retrieve-front-matter-keywords-value file type)))
+                                     (denote-keywords-combine kws)
+                                   (or (denote-retrieve-filename-keywords file) "")))
                         (cons ?% "%"))
                   'delete))))
 


### PR DESCRIPTION
The fix for #261 did not work for keywords, as `denote-retrieve-front-matter-keywords-value-as-string` returns an empty string when no keyword is found, which is considered as satisfying the `cond`. I propose instead to get the list of keywords using `denote-retrieve-front-matter-keywords-value`, combine them if non-empty, otherwise get the keywords from the file name.