### PR TITLE
Disable sluggification of keywords and signature, by default

### DIFF
--- a/README.org
+++ b/README.org
@@ -1727,8 +1727,8 @@ default value:
 
 #+begin_example emacs-lisp
 '((title . denote-sluggify-title)
-  (signature . denote-sluggify-signature)
-  (keyword . denote-sluggify-keyword))
+  (signature . identity)
+  (keyword . identity))
 #+end_example
 
 What these cons cells of =(COMPONENT . METHOD)= are:

--- a/denote.el
+++ b/denote.el
@@ -657,8 +657,8 @@ use `denote-sluggify-title' for the title.")
 
 (defvar denote-file-name-deslug-functions
   '((title . denote-desluggify-title)
-    (signature . denote-desluggify-signature)
-    (keyword . denote-desluggify-keyword))
+    (signature . identity)
+    (keyword . identity))
   "Specify the method Denote uses to reverse the process of `denote-sluggify'.
 
 Since `denote-sluggify' is destructive, this is just an attempt
@@ -670,8 +670,7 @@ display it as the default input in commands such as
 See the documentation of `denote-file-name-slug-functions'.
 
 By default, if a function is not specified for a component, we
-use `denote-desluggify-title', `denote-desluggify-keyword' and
-`denote-desluggify-signature'.")
+use `denote-desluggify-title' for the title.")
 
 ;;;; Main variables
 
@@ -899,9 +898,9 @@ to COMPONENT which is one of `title', `signature', `keyword'."
     (cond ((eq component 'title)
            (funcall (or deslug-function #'denote-desluggify-title) str))
           ((eq component 'keyword)
-           (funcall (or deslug-function #'denote-desluggify-keyword) str))
+           (funcall (or deslug-function #'identity) str))
           ((eq component 'signature)
-           (funcall (or deslug-function #'denote-desluggify-signature) str)))))
+           (funcall (or deslug-function #'identity) str)))))
 
 (defun denote-desluggify-title (str)
   "Upcase first char in STR and dehyphenate STR, inverting `denote-sluggify'.

--- a/denote.el
+++ b/denote.el
@@ -625,8 +625,8 @@ and `denote-link-after-creating-with-command'."
 
 (defvar denote-file-name-slug-functions
   '((title . denote-sluggify-title)
-    (signature . denote-sluggify-signature)
-    (keyword . denote-sluggify-keyword))
+    (signature . identity)
+    (keyword . identity))
   "Specify the method Denote uses to format the components of the file name.
 
 The value is an alist where each element is a cons cell of the
@@ -648,8 +648,7 @@ Note that the `keyword' function is also applied to the keywords
 of the front matter.
 
 By default, if a function is not specified for a component, we
-use `denote-sluggify-title', `denote-sluggify-keyword' and
-`denote-sluggify-signature'.")
+use `denote-sluggify-title' for the title.")
 
 (make-obsolete
  'denote-file-name-letter-casing
@@ -843,9 +842,9 @@ in file names."
                          ((eq component 'keyword)
                           (replace-regexp-in-string
                            "_" ""
-                           (funcall (or slug-function #'denote-sluggify-keyword) str)))
+                           (funcall (or slug-function #'identity) str)))
                          ((eq component 'signature)
-                          (funcall (or slug-function #'denote-sluggify-signature) str)))))
+                          (funcall (or slug-function #'identity) str)))))
     (denote--trim-right-token-characters
      (denote--replace-consecutive-token-characters
       (denote--remove-dot-characters str-slug) component) component)))


### PR DESCRIPTION
I suggest disabling sluggification of the keywords and signature
components of file names, by default, for these reasons:

- Sluggification of titles makes sense because it is a string of free
  text and it is desirable to make it "clean", by default, in a file's
  name. On the other hand, keywords and signature can be input in a
  correct manner from the start by the user.

- CamelCase or other schemes will be supported automatically.

- It is less necessary now that we always enforce the few rules that
  remains to the file naming scheme. Previously, the sluggification was
  taking care of this aspect, but not anymore.

- Ultimately, I would like to propose a change of the keywords separator
  from "_" to "__" and this step will help to make this less impactful
  to users.