### PR TITLE
Renaming commands

### DIFF
--- a/README.org
+++ b/README.org
@@ -1224,12 +1224,6 @@ The command does the same for the =SIGNATURE= prompt, subject to
 ~denote-prompts~, by prefilling the minibuffer with the current
 signature of =FILE=, if any.
 
-In interactive use, if =FILE= has a signature, ~denote-rename-file~
-produces a =SIGNATURE= prompt regardless of the value of ~denote-prompts~.
-This way, notes created with the ~denote-signature~ command, or
-equivalent, as a derogation from the norm imposed by ~denote-prompt~,
-do not necessarily lose their signature.
-
 Same principle for the =KEYWORDS= prompt: it converts the keywords in
 the file name into a comma-separated string and prefills the minibuffer
 with it (the =KEYWORDS= prompt accepts more than one keywords, each

--- a/denote.el
+++ b/denote.el
@@ -2753,14 +2753,9 @@ minibuffer that consists of the current title of FILE.  The
 current title is either retrieved from the front matter (such as
 the #+title in Org) or from the file name.
 
-Do the same for the SIGNATURE prompt, subject to `denote-prompts', by
-prefilling the minibuffer with the current signature of FILE, if any.
-
-In interactive use, if FILE has a signature, produce a SIGNATURE prompt
-regardless of the value of `denote-prompts'.  This way, notes created
-with the `denote-signature' command, or equivalent, as a derogation from
-the norm imposed by `denote-prompt', do not necessarily lose their
-signature.
+Do the same for the SIGNATURE prompt, subject to `denote-prompts',
+by prefilling the minibuffer with the current signature of FILE,
+if any.
 
 Same principle for the KEYWORDS prompt: convert the keywords in
 the file name into a comma-separated string and prefill the
@@ -2849,10 +2844,6 @@ one-by-one, use `denote-dired-rename-files'."
          ('date
           (unless (denote-file-has-identifier-p file)
             (aset args 3 (denote-date-prompt))))))
-     (when (denote-file-has-signature-p file)
-       (aset args 2 (denote-signature-prompt
-                     (or (denote-retrieve-filename-signature file) "")
-                     (format "Rename `%s' with SIGNATURE (empty to remove)" file-in-prompt))))
      (append (vector file) args nil)))
   (let* ((dir (file-name-directory file))
          (id (or (denote-retrieve-filename-identifier file)
@@ -2908,7 +2899,7 @@ setting `denote-rename-no-confirm' to a non-nil value)."
                               (denote-keywords-prompt
                                (format "Rename `%s' with KEYWORDS (empty to remove)" file-in-prompt)
                                (denote-convert-file-name-keywords-to-crm (or (denote-retrieve-filename-keywords file) ""))))))
-                 (signature (when (or signature-p (denote-file-has-signature-p file))
+                 (signature (when signature-p
                               (denote-signature-prompt
                                (or (denote-retrieve-filename-signature file) "")
                                (format "Rename `%s' with SIGNATURE (empty to remove)" file-in-prompt))))

--- a/denote.el
+++ b/denote.el
@@ -155,14 +155,14 @@ saved automatically."
   :package-version '(denote . "2.3.0")
   :type 'boolean)
 
-;;;###autoload (put 'denote-known-keywords 'safe-local-variable (lambda (val) (or (listp val) (null val))))
+;;;###autoload (put 'denote-known-keywords 'safe-local-variable #'listp)
 (defcustom denote-known-keywords
   '("emacs" "philosophy" "politics" "economics")
   "List of strings with predefined keywords for `denote'.
 Also see user options: `denote-infer-keywords',
 `denote-sort-keywords', `denote-file-name-slug-functions'."
   :group 'denote
-  :safe (lambda (val) (or (listp val) (null val)))
+  :safe #'listp
   :package-version '(denote . "0.1.0")
   :type '(repeat string))
 


### PR DESCRIPTION
In this pull request, I have done the following:

- Revert commit 232bd90 because of what is explained in #292.
- Make `denote-dired-rename-files` also obey the *order* of elements in
  `denote-prompts`.

I have also simplified a `:safe` declaration, since `nil` is a list (the empty list).