### PR TITLE
Remove denote-desluggify

### DIFF
--- a/README.org
+++ b/README.org
@@ -4313,11 +4313,6 @@ might change them without further notice.
 + Function ~denote-sluggify-keyword~ :: Sluggify =STR= while joining
   separate words.
 
-#+findex: denote-desluggify
-+ Function ~denote-desluggify~ :: Upcase first char in =STR= and
-  dehyphenate =STR=, inverting ~denote-sluggify~.  Basically, convert
-  =this-is-a-test= to =This is a test=.
-
 #+findex: denote-sluggify-signature
 + Function ~denote-sluggify-signature~ :: Make =STR= an appropriate
   slug for signatures ([[#h:ae8b19a1-7f67-4258-96b3-370a72c43f4e][Sluggification of file name components]]).

--- a/tests/denote-test.el
+++ b/tests/denote-test.el
@@ -96,11 +96,6 @@ The function also account for the value of the user option
    (equal (denote-sluggify-keywords '("one !@# --- one" "   two" "__  three  __"))
           '("oneone" "two" "three"))))
 
-(ert-deftest denote-test--denote-desluggify ()
-  "Test that `denote-desluggify' upcases first character and de-hyphenates string."
-  (should (equal (denote-desluggify 'title "this-is-a-test") "This is a test"))
-  (should (null (equal (denote-desluggify 'title "this=is=a=test") "This is a test"))))
-
 (ert-deftest denote-test--denote--file-empty-p ()
   "Test that `denote--file-empty-p' returns non-nil on empty file."
   ;; (should (null (denote--file-empty-p user-init-file))


### PR DESCRIPTION
Hello Prot,

I suggest that we remove `denote-file-name-deslug-function` from the
upcoming version 2.3.0 because it will be new in this version and
it is actually not very useful.

First, desluggification of keywords and signature is never used in the
code base, so this part is totally useless. As for the title
desluggification, it is only used in
`denote-retrieve-title-or-filename`. This is used in renaming commands
to provide a suggested title and for the link descriptions. This only
applies when we cannot find the title from the front-matter and there is
a title in the file name. I think the raw title (not desluggified) is
not a bad suggestion/description in those cases. The desluggified
suggestion may not be useful enough to warrant a user option.

Ignore this pull request if you think this is still useful and we should
keep it.