### PR TITLE
Actually... remove `project.el` integration again

### DIFF
--- a/denote.el
+++ b/denote.el
@@ -4073,31 +4073,6 @@ To be assigned to `markdown-follow-link-functions'."
 
 ;;;;; Backlinks' buffer
 
-(cl-defmethod project-root ((project (head denote)))
-  "Denote's implementation of `project-root' method from `project'.
-Return current variable `denote-directory' as the root of the
-current denote PROJECT."
-  (cdr project))
-
-(cl-defmethod project-files ((_project (head denote)) &optional _dirs)
-  "Denote's implementation of `project-files' method from `project'.
-Return all files that have an identifier for the current denote
-PROJECT.  The return value may thus include file types that are
-not implied by `denote-file-type'.  To limit the return value to
-text files, use the function `denote-directory-files' with a
-non-nil `text-only' parameter."
-  (denote-directory-files))
-
-(defun denote-project-find (dir)
-  "Return project instance if DIR is part of variable `denote-directory'.
-The format of project instance is aligned with `project-try-vc'
-defined in `project'."
-  (let ((dir (expand-file-name dir))
-        (root (denote-directory)))
-    (when (or (file-equal-p dir root)
-              (string-prefix-p root dir))
-      (cons 'denote root))))
-
 (define-button-type 'denote-link-backlink-button
   'follow-link t
   'action #'denote-link--backlink-find-file
@@ -4170,8 +4145,7 @@ matching identifiers."
   :interactive nil
   "Major mode for backlinks buffers."
   (unless denote-backlinks-show-context
-    (font-lock-add-keywords nil denote-faces-file-name-keywords t))
-  (add-hook 'project-find-functions #'denote-project-find nil t))
+    (font-lock-add-keywords nil denote-faces-file-name-keywords t)))
 
 (defun denote-link--prepare-backlinks (fetcher _alist)
   "Create backlinks' buffer for the current note.
@@ -4189,8 +4163,18 @@ ALIST is not used in favour of using
          (file-type (denote-filetype-heuristics file))
          (id (denote-retrieve-filename-identifier-with-error file))
          (buf (format "*denote-backlinks to %s*" id))
+         ;; We retrieve results in absolute form and change the absolute
+         ;; path to a relative path a few lines below. We could add a
+         ;; suitable function to project-find-functions and the results
+         ;; would be automatically in relative form, but eventually
+         ;; notes may not be all under a common directory (or project).
+         (xref-file-name-display 'abs)
          (xref-alist (xref--analyze (funcall fetcher)))
          (dir (denote-directory)))
+    ;; Change the GROUP of each item in xref-alist to a relative path
+    (mapc (lambda (x)
+            (setf (car x) (denote-get-file-name-relative-to-denote-directory (car x))))
+          xref-alist)
     (with-current-buffer (get-buffer-create buf)
       (setq-local default-directory dir)
       (erase-buffer)
@@ -4241,8 +4225,7 @@ default, it will show up below the current window."
   (let ((file (buffer-file-name)))
     (when (denote-file-is-writable-and-supported-p file)
       (let* ((id (denote-retrieve-filename-identifier-with-error file))
-             (xref-show-xrefs-function #'denote-link--prepare-backlinks)
-             (project-find-functions #'denote-project-find))
+             (xref-show-xrefs-function #'denote-link--prepare-backlinks))
         (xref--show-xrefs
          (apply-partially #'xref-matches-in-files id
                           (denote-directory-files nil :omit-current :text-only))


### PR DESCRIPTION
When removing modules, we removed `project.el` integration at the same
time. This caused an issue with backlinks because xref can use relative
file names (relative to the current project).

However, it is better to have xref retrieve its results in absolute form
and then arrange the results to relative form ourselves because,
eventually, notes will not be all under the same directory/project.

I have thus removed `project.el` integration again and fixed the code to
still use relative paths. I am unsure why we added `denote-project-find`
to `project-find-functions` hook for backlinks buffer. I suspect it was
to support relative paths somehow. I have removed it and tested the
backlinks buffers and they work as intended.

This is ready to be merged. It can be part of 2.3.0 as you have already
removed Denote modules.