### PR TITLE
Remove unused functions

### DIFF
--- a/README.org
+++ b/README.org
@@ -4156,13 +4156,6 @@ might change them without further notice.
   ~denote-known-keywords~.  Else use only the latter set of keywords
   ([[#h:6a92a8b5-d766-42cc-8e5b-8dc255466a23][Standard note creation]]).
 
-#+findex: denote-convert-file-name-keywords-to-crm
-+ Function ~denote-convert-file-name-keywords-to-crm~ :: Make =STRING=
-  with keywords readable by ~completing-read-multiple~. =STRING=
-  consists of underscore-separated words, as those appear in the
-  keywords component of a Denote file name. =STRING= is the same as
-  the return value of ~denote-retrieve-filename-keywords~.
-
 #+findex: denote-keywords-sort
 + Function ~denote-keywords-sort~ :: Sort =KEYWORDS= if
   ~denote-sort-keywords~ is non-nil.  =KEYWORDS= is a list of strings,

--- a/README.org
+++ b/README.org
@@ -4354,16 +4354,7 @@ might change them without further notice.
 #+findex: denote-retrieve-front-matter-keywords-value
 + Function ~denote-retrieve-front-matter-keywords-value~ :: Return keywords value
   from =FILE= front matter per =FILE-TYPE=. The return value is a list
-  of strings. To get a combined string the way it would appear in a
-  Denote file name, use ~denote-retrieve-front-matter-keywords-value-as-string~.
-
-#+findex: denote-retrieve-front-matter-keywords-value-as-string
-+ Function ~denote-retrieve-front-matter-keywords-value-as-string~ :: Return
-  keywords value from =FILE= front matter per =FILE-TYPE=. The return
-  value is a string, with the underscrore as a separator between
-  individual keywords. To get a list of strings instead, use
-  ~denote-retrieve-front-matter-keywords-value~ (the current function uses that
-  internally).
+  of strings.
 
 #+findex: denote-retrieve-front-matter-keywords-line
 + Function ~denote-retrieve-front-matter-keywords-line~ :: Return keywords line

--- a/denote.el
+++ b/denote.el
@@ -1217,13 +1217,6 @@ Inferred keywords are filtered by the user option
        (append (denote--inferred-keywords) denote-known-keywords)
      denote-known-keywords)))
 
-(defun denote-convert-file-name-keywords-to-crm (string)
-  "Make STRING with keywords readable by `completing-read-multiple'.
-STRING consists of underscore-separated words, as those appear in
-the keywords component of a Denote file name.  STRING is the same
-as the return value of `denote-retrieve-filename-keywords'."
-  (string-join (split-string string "_" :omit-nulls "_") ","))
-
 (defvar denote-keyword-history nil
   "Minibuffer history of inputted keywords.")
 

--- a/denote.el
+++ b/denote.el
@@ -1733,21 +1733,11 @@ Subroutine of `denote--file-with-temp-buffer'."
 
 (defun denote-retrieve-front-matter-keywords-value (file file-type)
   "Return keywords value from FILE front matter per FILE-TYPE.
-The return value is a list of strings.  To get a combined string
-the way it would appear in a Denote file name, use
-`denote-retrieve-front-matter-keywords-value-as-string'."
+The return value is a list of strings."
   (denote--file-with-temp-buffer file
     (when (re-search-forward (denote--keywords-key-regexp file-type) nil t 1)
       (funcall (denote--keywords-value-reverse-function file-type)
                (buffer-substring-no-properties (point) (line-end-position))))))
-
-(defun denote-retrieve-front-matter-keywords-value-as-string (file file-type)
-  "Return keywords value from FILE front matter per FILE-TYPE.
-The return value is a string, with the underscrore as a separator
-between individual keywords.  To get a list of strings instead,
-use `denote-retrieve-front-matter-keywords-value' (the current function uses
-that internally)."
-  (denote-keywords-combine (denote-retrieve-front-matter-keywords-value file file-type)))
 
 (defun denote-retrieve-front-matter-keywords-line (file file-type)
   "Return keywords line from FILE front matter per FILE-TYPE."
@@ -1766,9 +1756,6 @@ that internally)."
 
 (defalias 'denote-retrieve-keywords-line 'denote-retrieve-front-matter-keywords-line
  "Alias for `denote-retrieve-front-matter-keywords-line'.")
-
-(defalias 'denote-retrieve-keywords-value-as-string 'denote-retrieve-front-matter-keywords-value-as-string
- "Alias for `denote-retrieve-front-matter-keywords-value-as-string'.")
 
 (define-obsolete-function-alias
   'denote--retrieve-title-or-filename

--- a/tests/denote-test.el
+++ b/tests/denote-test.el
@@ -391,13 +391,6 @@ Extend what we do in `denote-test--denote-file-type-extensions'."
                (eq (denote-filetype-heuristics "20231010T105034--some-test-file__denote_testing.md.gpg") 'markdown-yaml)
                (eq (denote-filetype-heuristics "20231010T105034--some-test-file__denote_testing.md.age") 'markdown-yaml))))
 
-(ert-deftest denote-test--denote-convert-file-name-keywords-to-crm ()
-  "Ensure that `denote-convert-file-name-keywords-to-crm' returns words as comma-separated string."
-  (should
-   (and (equal (denote-convert-file-name-keywords-to-crm "_denote_keywords_testing") "denote,keywords,testing")
-        (equal (denote-convert-file-name-keywords-to-crm "_denote") "denote")
-        (equal (denote-convert-file-name-keywords-to-crm "") ""))))
-
 (ert-deftest denote-test--denote-get-identifier ()
   "Test that `denote-get-identifier' returns an identifier."
   (should (and (equal (denote-get-identifier) (format-time-string denote-id-format (current-time)))


### PR DESCRIPTION
Consider removing `denote-convert-keywords-to-crm`. We never use it because it always makes more sense to work with keywords as a list. It is better to use `denote-extract-keywords-from-path`.

We can also remove `denote-retrieve-front-matter-keywords-value-as-string` for similar reasons.

Let me know if you think it is necessary to make them obsolete for now instead or if you would like to keep one or both of the functions. I think it is better to encourage the manipulation of keywords as a list and we already have suitable functions for that.