### PR TITLE
Refactorings

### DIFF
--- a/denote.el
+++ b/denote.el
@@ -4184,7 +4184,7 @@ concomitant alist, such as `denote-link-backlinks-display-buffer-action'."
 Use FILE to detect a suitable title with which to name the buffer.  Else
 use the ID."
   (if-let ((type (denote-filetype-heuristics file))
-           (title (denote-retrieve-title-value file type)))
+           (title (denote-retrieve-front-matter-title-value file type)))
       (format "*Denote FILE backlinks for %S*" title)
     (format "*Denote FILE backlinks for %s*" id)))
 

--- a/denote.el
+++ b/denote.el
@@ -1113,7 +1113,7 @@ something like .org even if the actual file extension is
   (let ((files
          (seq-filter
           (lambda (file)
-            (string-prefix-p id (file-name-nondirectory file)))
+            (string= id (denote-retrieve-filename-identifier file)))
           (denote-directory-files))))
     (if (length< files 2)
         (car files)
@@ -1986,7 +1986,7 @@ If either that or DATE is nil, return `current-time'."
   "Return non-nil if IDENTIFIER already exists."
   (seq-some
    (lambda (file)
-     (string-prefix-p identifier (file-name-nondirectory file)))
+     (string= identifier (denote-retrieve-filename-identifier file)))
    (append (denote-directory-files) (denote--buffer-file-names))))
 
 (defun denote--get-all-used-ids ()
@@ -3810,7 +3810,7 @@ function."
         found-files)
     (dolist (file files)
       (dolist (i (denote-link--collect-identifiers regexp))
-        (when (string-prefix-p i (file-name-nondirectory file))
+        (when (string= i (denote-retrieve-filename-identifier file))
           (push file found-files))))
     found-files))
 


### PR DESCRIPTION
Two commits. Nothing major or breaking.

- Use `denote-retrieve-front-matter-title-value` instead of an alias
- Use `denote-retrieve-filename-identifier` and compare id with `string=` instead of `string-prefix-p`. This is more general and will be ready for when file name components are in a different order.