### PR TITLE
Other fixes

### DIFF
--- a/denote.el
+++ b/denote.el
@@ -1617,7 +1617,7 @@ contain the newline."
     (with-temp-buffer
       (insert front-matter)
       (goto-char (point-min))
-      (when (re-search-forward key-regexp nil :no-error 1)
+      (when (re-search-forward key-regexp nil t 1)
         (buffer-substring-no-properties (line-beginning-position) (line-end-position))))))
 
 (defun denote--get-keywords-line-from-front-matter (keywords file-type)
@@ -1629,7 +1629,7 @@ contain the newline."
     (with-temp-buffer
       (insert front-matter)
       (goto-char (point-min))
-      (when (re-search-forward key-regexp nil :no-error 1)
+      (when (re-search-forward key-regexp nil t 1)
         (buffer-substring-no-properties (line-beginning-position) (line-end-position))))))
 
 ;;;; Front matter or content retrieval functions
@@ -1741,7 +1741,7 @@ Subroutine of `denote--file-with-temp-buffer'."
   "Return title value from FILE front matter per FILE-TYPE."
   (denote--file-with-temp-buffer file
     (when (and file-type
-               (re-search-forward (denote--title-key-regexp file-type) nil :no-error 1))
+               (re-search-forward (denote--title-key-regexp file-type) nil t 1))
       (funcall (denote--title-value-reverse-function file-type)
                (buffer-substring-no-properties (point) (line-end-position))))))
 
@@ -1749,7 +1749,7 @@ Subroutine of `denote--file-with-temp-buffer'."
   "Return title line from FILE front matter per FILE-TYPE."
   (denote--file-with-temp-buffer file
     (when (and file-type
-               (re-search-forward (denote--title-key-regexp file-type) nil :no-error 1))
+               (re-search-forward (denote--title-key-regexp file-type) nil t 1))
       (buffer-substring-no-properties (line-beginning-position) (line-end-position)))))
 
 (defun denote-retrieve-front-matter-keywords-value (file file-type)
@@ -1757,7 +1757,7 @@ Subroutine of `denote--file-with-temp-buffer'."
 The return value is a list of strings."
   (denote--file-with-temp-buffer file
     (when (and file-type
-               (re-search-forward (denote--keywords-key-regexp file-type) nil :no-error 1))
+               (re-search-forward (denote--keywords-key-regexp file-type) nil t 1))
       (funcall (denote--keywords-value-reverse-function file-type)
                (buffer-substring-no-properties (point) (line-end-position))))))
 
@@ -1765,7 +1765,7 @@ The return value is a list of strings."
   "Return keywords line from FILE front matter per FILE-TYPE."
   (denote--file-with-temp-buffer file
     (when (and file-type
-               (re-search-forward (denote--keywords-key-regexp file-type) nil :no-error 1))
+               (re-search-forward (denote--keywords-key-regexp file-type) nil t 1))
       (buffer-substring-no-properties (line-beginning-position) (line-end-position)))))
 
 (defalias 'denote-retrieve-title-value 'denote-retrieve-front-matter-title-value
@@ -2230,7 +2230,7 @@ Note that a non-nil value other than `text', `markdown-yaml', and
 `markdown-toml' falls back to an Org file type.  We use `org'
 here for clarity."
   (completing-read
-   "Select file TYPE: " (denote--file-type-keys) nil :require-match
+   "Select file TYPE: " (denote--file-type-keys) nil t
    nil 'denote-file-type-history))
 
 (defvar denote-date-history nil
@@ -2278,7 +2278,7 @@ Use Org's more advanced date selection utility if the user option
          (prompt (if def
                      (format "Select SUBDIRECTORY [%s]: " def)
                    "Select SUBDIRECTORY: ")))
-    (completing-read prompt table nil :require-match nil 'denote-subdirectory-history def)))
+    (completing-read prompt table nil t nil 'denote-subdirectory-history def)))
 
 (defun denote-subdirectory-prompt ()
   "Prompt for subdirectory of the variable `denote-directory'.
@@ -2302,7 +2302,7 @@ packages such as `marginalia' and `embark')."
      (intern
       (completing-read
        "Select TEMPLATE key: " (mapcar #'car templates)
-       nil :require-match nil 'denote-template-history))
+       nil t nil 'denote-template-history))
      templates)))
 
 (defvar denote-signature-history nil
@@ -2575,7 +2575,7 @@ block if appropriate."
 (defun denote--regexp-in-file-p (regexp file)
   "Return t if REGEXP matches in the FILE."
   (denote--file-with-temp-buffer file
-    (re-search-forward regexp nil :no-error 1)))
+    (re-search-forward regexp nil t 1)))
 
 (defun denote--edit-front-matter-p (file file-type)
   "Test if FILE should be subject to front matter rewrite.
@@ -2605,7 +2605,7 @@ related."
       (save-restriction
         (widen)
         (goto-char (point-min))
-        (when (re-search-forward (denote--keywords-key-regexp file-type) nil :no-error 1)
+        (when (re-search-forward (denote--keywords-key-regexp file-type) nil t 1)
           (goto-char (line-beginning-position))
           (insert (denote--get-keywords-line-from-front-matter keywords file-type))
           (delete-region (point) (line-end-position))
@@ -2641,12 +2641,12 @@ produce a `y-or-n-p' prompt to that effect."
           (save-restriction
             (widen)
             (goto-char (point-min))
-            (re-search-forward (denote--title-key-regexp file-type) nil :no-error 1)
+            (re-search-forward (denote--title-key-regexp file-type) nil t 1)
             (goto-char (line-beginning-position))
             (insert new-title-line)
             (delete-region (point) (line-end-position))
             (goto-char (point-min))
-            (re-search-forward (denote--keywords-key-regexp file-type) nil :no-error 1)
+            (re-search-forward (denote--keywords-key-regexp file-type) nil t 1)
             (goto-char (line-beginning-position))
             (insert new-keywords-line)
             (delete-region (point) (line-end-position))))))))
@@ -3668,8 +3668,8 @@ function."
   (let (matches)
     (save-excursion
       (goto-char (point-min))
-      (while (or (re-search-forward regexp nil :no-error)
-                 (re-search-forward denote-id-only-link-in-context-regexp nil :no-error))
+      (while (or (re-search-forward regexp nil t)
+                 (re-search-forward denote-id-only-link-in-context-regexp nil t))
         (push (match-string-no-properties 1) matches)))
     matches))
 
@@ -3696,7 +3696,7 @@ function."
     (completing-read
      "Find linked file: "
      (denote--completion-table 'file file-names)
-     nil :require-match nil 'denote-link-find-file-history)))
+     nil t nil 'denote-link-find-file-history)))
 
 (define-obsolete-function-alias
   'denote-link--find-file-prompt
@@ -3909,7 +3909,7 @@ positions, limit the process to the region in-between."
              (denote-file-has-identifier-p buffer-file-name))
     (save-excursion
       (goto-char (or beg (point-min)))
-      (while (re-search-forward denote-id-regexp end :no-error)
+      (while (re-search-forward denote-id-regexp end t)
         (when-let ((string (denote-link--link-at-point-string))
                    (beg (match-beginning 0))
                    (end (match-end 0)))
@@ -4179,7 +4179,7 @@ inserts links with just the identifier."
     (completing-read
      "Select note buffer: "
      (denote--completion-table 'buffer buffer-file-names)
-     nil :require-match)))
+     nil t)))
 
 (defun denote-link--map-over-notes ()
   "Return list of `denote-file-is-note-p' from Dired marked items."

--- a/denote.el
+++ b/denote.el
@@ -956,7 +956,9 @@ For our purposes, a note must satisfy `file-regular-p' and
 
 (defun denote-file-is-writable-and-supported-p (file)
   "Return non-nil if FILE is writable and has supported extension."
-  (and (denote--file-regular-writable-p file)
+  ;; We do not want to test that the file is regular (exists) because we want
+  ;; this function to return t on files that are still unsaved.
+  (and (file-writable-p file)
        (denote-file-has-supported-extension-p file)))
 
 (defun denote-get-file-name-relative-to-denote-directory (file)
@@ -3096,7 +3098,8 @@ cannot know if they have front matter and what that may be."
   (interactive nil dired-mode)
   (if-let ((marks (seq-filter
                    (lambda (m)
-                     (and (denote-file-is-writable-and-supported-p m)
+                     (and (file-regular-p m)
+                          (denote-file-is-writable-and-supported-p m)
                           (denote-file-has-identifier-p m)))
                    (dired-get-marked-files))))
       (progn

--- a/denote.el
+++ b/denote.el
@@ -1920,6 +1920,8 @@ TEMPLATE, and SIGNATURE should be valid for note creation."
                   title (denote--date date file-type) keywords
                   id
                   file-type)))
+    (when (file-regular-p buffer)
+      (user-error "A file named `%s' already exists" buffer))
     (with-current-buffer buffer
       (insert header)
       (insert template))
@@ -2730,6 +2732,8 @@ Respect `denote-rename-confirmations' and `denote-save-buffers'."
                  (denote-create-unique-file-identifier file date)))
          (new-name (denote-format-file-name directory id keywords title extension signature))
          (max-mini-window-height denote-rename-max-mini-window-height))
+    (when (file-regular-p new-name)
+      (user-error "The destination file `%s' already exists" new-name))
     (when (denote-rename-file-prompt file new-name)
       ;; Modify file name, buffer name, or both
       (denote-rename-file-and-buffer file new-name)
@@ -4537,6 +4541,8 @@ Consult the manual for template samples."
                           (denote-get-identifier) 'org)))
       (setq denote-last-path
             (denote-format-file-name directory id keywords title ".org" signature))
+      (when (file-regular-p denote-last-path)
+        (user-error "A file named `%s' already exists" denote-last-path))
       (denote--keywords-add-to-history keywords)
       (concat front-matter template denote-org-capture-specifiers))))
 

--- a/denote.el
+++ b/denote.el
@@ -1739,34 +1739,34 @@ Subroutine of `denote--file-with-temp-buffer'."
 
 (defun denote-retrieve-front-matter-title-value (file file-type)
   "Return title value from FILE front matter per FILE-TYPE."
-  (denote--file-with-temp-buffer file
-    (when (and file-type
-               (re-search-forward (denote--title-key-regexp file-type) nil t 1))
-      (funcall (denote--title-value-reverse-function file-type)
-               (buffer-substring-no-properties (point) (line-end-position))))))
+  (when file-type
+    (denote--file-with-temp-buffer file
+      (when (re-search-forward (denote--title-key-regexp file-type) nil t 1)
+        (funcall (denote--title-value-reverse-function file-type)
+                 (buffer-substring-no-properties (point) (line-end-position)))))))
 
 (defun denote-retrieve-front-matter-title-line (file file-type)
   "Return title line from FILE front matter per FILE-TYPE."
-  (denote--file-with-temp-buffer file
-    (when (and file-type
-               (re-search-forward (denote--title-key-regexp file-type) nil t 1))
-      (buffer-substring-no-properties (line-beginning-position) (line-end-position)))))
+  (when file-type
+    (denote--file-with-temp-buffer file
+      (when (re-search-forward (denote--title-key-regexp file-type) nil t 1)
+        (buffer-substring-no-properties (line-beginning-position) (line-end-position))))))
 
 (defun denote-retrieve-front-matter-keywords-value (file file-type)
   "Return keywords value from FILE front matter per FILE-TYPE.
 The return value is a list of strings."
-  (denote--file-with-temp-buffer file
-    (when (and file-type
-               (re-search-forward (denote--keywords-key-regexp file-type) nil t 1))
-      (funcall (denote--keywords-value-reverse-function file-type)
-               (buffer-substring-no-properties (point) (line-end-position))))))
+  (when file-type
+    (denote--file-with-temp-buffer file
+      (when (re-search-forward (denote--keywords-key-regexp file-type) nil t 1)
+        (funcall (denote--keywords-value-reverse-function file-type)
+                 (buffer-substring-no-properties (point) (line-end-position)))))))
 
 (defun denote-retrieve-front-matter-keywords-line (file file-type)
   "Return keywords line from FILE front matter per FILE-TYPE."
-  (denote--file-with-temp-buffer file
-    (when (and file-type
-               (re-search-forward (denote--keywords-key-regexp file-type) nil t 1))
-      (buffer-substring-no-properties (line-beginning-position) (line-end-position)))))
+  (when file-type
+    (denote--file-with-temp-buffer file
+      (when (re-search-forward (denote--keywords-key-regexp file-type) nil t 1)
+        (buffer-substring-no-properties (line-beginning-position) (line-end-position))))))
 
 (defalias 'denote-retrieve-title-value 'denote-retrieve-front-matter-title-value
   "Alias for `denote-retrieve-front-matter-title-value'.")


### PR DESCRIPTION
In this PR, I have addressed your comment in my previous PR and introduced a
few more cleanups.

The changes will help with resolving #279 to allow renaming new notes that are still
unsaved.

I also added checks to creation and renaming commands to avoid creating a note
if the file already exists. This is not a concern for now because the id is
unique and part of the file name, but we may want to make it optional
eventually.

Just a comment regarding your last commit: The change is not only stylistic:
`re-search-forward` behave differently whether `NOERROR` is `t` or any other
non-nil value such as `:no-error`. Check its docstring. I have discovered this
myself as well while working on the upcoming new fontification. Same thing
with `completing-read`: `t` and `:require-match` do not have the same
behaviors.

I have reverted your commit myself as it could conflict with a change I needed
to make to address one of your comment on my previous pull request.