### PR TITLE
Fix issue on note creation caused by commit bce7778

### DIFF
--- a/denote.el
+++ b/denote.el
@@ -1922,8 +1922,8 @@ TEMPLATE, and SIGNATURE should be valid for note creation."
                   title (denote--date date file-type) keywords
                   id
                   file-type)))
-    (when (file-regular-p buffer)
-      (user-error "A file named `%s' already exists" buffer))
+    (when (file-regular-p path)
+      (user-error "A file named `%s' already exists" path))
     (with-current-buffer buffer
       (insert header)
       (insert template))


### PR DESCRIPTION
I made this pull request to fix my mistake as reported in #357. Sorry about this!

I may add another commit soon. I feel like there is something awkward with the
way we handle the title and the renaming convenience commands. For example,
`denote-rename-file-signature` called on a file that is not yet a Denote file.
This is a case I may not have considered in my refactoring.

Anyway, don't wait to merge this current pull request.

resolves #357