### PR TITLE
Bug fixes: Fix the fontification + another bug

### DIFF
--- a/denote.el
+++ b/denote.el
@@ -1940,8 +1940,9 @@ which case it is not added to the base file name."
             ((and (eq component 'signature) signature (not (string-empty-p signature)))
              (setq file-name (concat file-name "==" (denote-sluggify 'signature signature))))))
     (setq file-name (concat file-name extension))
-    ;; Do not prepend identifier with @@ if it is the first component.
-    (when (string-prefix-p "@@" file-name)
+    ;; Do not prepend identifier with @@ if it is the first component and has the format 00000000T000000.
+    (when (and (string-prefix-p "@@" file-name)
+               (string-match-p (concat "\\`" denote-id-regexp "\\'") id)) ; This is always true for now.
       (setq file-name (substring file-name 2)))
     (concat dir-path file-name)))
 

--- a/denote.el
+++ b/denote.el
@@ -3506,9 +3506,17 @@ and seconds."
 (defun denote-faces-dired-file-name-matcher (limit)
   "Find the file name in a Dired line, not looking beyond LIMIT."
   (let ((initial-match-data (match-data))
-        (initial-point (point)))
-    (if (and (re-search-forward "^.+$" limit t) ; A non-empty line
-             (dired-move-to-filename))          ; ... with a file name
+        (initial-point (point))
+        (line-found nil))
+    ;; Find the next non empty line that contains a Dired file name
+    (while (and (not line-found)
+                (re-search-forward "^.+$" limit t))
+      ;; dired-move-to-filename moves the point even if it returns nil
+      (let ((saved-point (point)))
+        (if (dired-move-to-filename)
+            (setq line-found t)
+          (goto-char saved-point))))
+    (if line-found
         (let ((beginning-point (point)))
           (goto-char (match-end 0))
           (set-match-data (list beginning-point (match-end 0)))

--- a/denote.el
+++ b/denote.el
@@ -3552,6 +3552,20 @@ and seconds."
       (set-match-data initial-match-data)
       nil)))
 
+(defun denote-faces-identifier-matcher (limit)
+  "Match a general identifier in a Dired line, not looking beyond LIMIT."
+  (let ((initial-match-data (match-data))
+        (initial-point (point)))
+    (if (or (re-search-forward "@@\\(?1:[^/]*?\\)\\(@@\\|--\\|__\\|==\\|\\.\\)[^/]*$" limit t)
+            (re-search-forward "@@\\(?1:[^/]*\\)$" limit t))
+        (progn
+          (goto-char (match-end 1))
+          (set-match-data (list (match-beginning 1) (match-end 1)))
+          (point))
+      (goto-char initial-point)
+      (set-match-data initial-match-data)
+      nil)))
+
 (defun denote-faces-title-matcher (limit)
   "Match the title in a Dired line, not looking beyond LIMIT."
   (let ((initial-match-data (match-data))
@@ -3585,7 +3599,7 @@ and seconds."
      (goto-char (match-beginning 0))
      (goto-char (match-end 0))
      (0 'denote-faces-subdirectory nil t))
-    ;; Identifier anywhere in the file name.
+    ;; Identifier with format 00000000T000000
     ("\\(?1:[0-9]\\{4\\}\\)\\(?2:[0-9]\\{2\\}\\)\\(?3:[0-9]\\{2\\}\\)\\(?7:T\\)\\(?4:[0-9]\\{2\\}\\)\\(?5:[0-9]\\{2\\}\\)\\(?6:[0-9]\\{2\\}\\)"
      (goto-char (match-beginning 0)) ; pre-form, executed before looking for the first identifier
      (goto-char (match-end 0))       ; post-form, executed after all matches (identifiers here) are found
@@ -3596,6 +3610,11 @@ and seconds."
      (5 'denote-faces-minute nil t)
      (6 'denote-faces-second nil t)
      (7 'denote-faces-delimiter nil t))
+    ;; Identifier with general format (not yet possible)
+    (denote-faces-identifier-matcher
+     (goto-char (match-beginning 0))
+     (goto-char (match-end 0))
+     (0 'denote-faces-date nil t))
     ;; Title
     (denote-faces-title-matcher
      (goto-char (match-beginning 0))

--- a/denote.el
+++ b/denote.el
@@ -2102,8 +2102,13 @@ It checks files in variable `denote-directory' and active buffer files."
 If ID is already used, increment it 1 second at a time until an
 available id is found."
   (let ((used-ids (or denote--used-ids (denote--get-all-used-ids)))
-        (current-id id))
+        (current-id id)
+        (iteration 0))
     (while (gethash current-id used-ids)
+      ;; Prevent infinite loop if `denote-id-format' is misconfigured
+      (setq iteration (1+ iteration))
+      (when (>= iteration 10000)
+        (user-error "A unique identifier could not be found"))
       (setq current-id (denote-get-identifier (time-add (date-to-time current-id) 1))))
     current-id))
 

--- a/denote.el
+++ b/denote.el
@@ -4799,8 +4799,7 @@ Consult the manual for template samples."
                 (denote--creation-prepare-note-data title keywords 'org directory date template signature))
                (id (denote--find-first-unused-id (denote-get-identifier date)))
                (front-matter (denote--format-front-matter
-                              title (denote--date nil 'org) keywords
-                              (denote-get-identifier) 'org)))
+                              title (denote--date nil 'org) keywords id 'org)))
     (setq denote-last-path
           (denote-format-file-name directory id keywords title ".org" signature))
     (when (file-regular-p denote-last-path)


### PR DESCRIPTION
Bug fixes:

- This fixes the fontification. If we have issues with that in the future, we
  can also replace `denote-faces-dired-file-name-matcher` with the function
  [`dired-filename-search-forward`](https://github.com/protesilaos/denote/issues/271#issuecomment-2113961191) that mentalisttraceur shared in #271.
  I tested it as well and it worked. Just mentioning it as a possible alternative.

- I also found another unrelated bug: `denote-org-capture` would always use
  the current time for the id in the front matter irrespective of the value of
  a possible date prompt.

I added some safeguards for when we will allow identifiers to have other
formats. The code is useless for now, but it is ready.

- I made the fontification ready to handle any identifier format.

- Prevent infinite loops in case `denote-id-format` is misconfigured.

- Make sure that only identifiers that have the specific format
  00000000T000000 are allowed to drop their delimiter in file names. This is
  important if we decide at some point that titles can drop their delimiter in
  first position. We don't want ambiguity with an arbitrary identifier. This
  is to keep our options open for the future.