### PR TITLE
Add indicator for buffer having backlinks to denote-rename-buffer

### DIFF
--- a/README.org
+++ b/README.org
@@ -3009,6 +3009,7 @@ are placeholders for Denote file name components ([[#h:4e9c7512-84dc-4dfb-9fa9-e
 - The =%d= is the same as =%i= (=DATE= mnemonic).
 - The =%s= is the Denote =SIGNATURE= of the file.
 - The =%k= is the Denote =KEYWORDS= of the file.
+- The =%b= is an indicator of whether or not the file has backlinks pointing to it.
 - The =%%= is a literal percent sign.
 
 In addition, the following flags are available for each of the specifiers:
@@ -3029,8 +3030,11 @@ include some text that makes Denote buffers stand out, such as
 a =[D]= prefix.  Examples:
 
 #+begin_src emacs-lisp
-;; Use the title (default)
-(setq denote-rename-buffer-format "%t")
+;; Use the title prefixed with the backlink indicator (default)
+(setq denote-rename-buffer-format "%b%t")
+
+;; Customize what the backlink indicator looks like
+(setq denote-buffer-has-backlinks-string "!! ")
 
 ;; Use the title and keywords with some emoji in between
 (setq denote-rename-buffer-format "%t 🤨 %k")

--- a/denote-rename-buffer.el
+++ b/denote-rename-buffer.el
@@ -98,14 +98,16 @@ buffer will be used, if available."
   "Parse the BUFFER through the `denote-rename-buffer-format'."
   (when-let ((file (buffer-file-name buffer))
              (type (denote-filetype-heuristics file)))
-    (let ((has-backlinks (not (zerop (length (denote-link-return-backlinks file))))))
+    (let ((should-show-backlink-indicator (and ; only do search if format contains "%b"
+                                           (string-match-p "%b" denote-rename-buffer-format)
+                                           (denote--file-has-backlinks-p file))))
       (string-trim
        (format-spec denote-rename-buffer-format
                     (list (cons ?t (cond
                                     ((denote-retrieve-front-matter-title-value file type))
                                     ((denote-retrieve-filename-title file))
                                     (t  "")))
-                          (cons ?b (if has-backlinks denote-buffer-has-backlinks-string ""))
+                          (cons ?b (if should-show-backlink-indicator denote-buffer-has-backlinks-string ""))
                           (cons ?i (or (denote-retrieve-filename-identifier file) ""))
                           (cons ?d (or (denote-retrieve-filename-identifier file) ""))
                           (cons ?s (or (denote-retrieve-filename-signature file) ""))

--- a/denote-rename-buffer.el
+++ b/denote-rename-buffer.el
@@ -38,11 +38,18 @@
   :link '(info-link "(denote) Top")
   :link '(url-link :tag "Homepage" "https://protesilaos.com/emacs/denote"))
 
-(defcustom denote-rename-buffer-format "%t"
+(defcustom denote-buffer-has-backlinks-string "→ "
+  "A string used to indicate that a buffer has backlinks pointing to it."
+  :type 'string
+  :package-version '(denote . "2.1.0")
+  :group 'denote-rename-buffer)
+
+(defcustom denote-rename-buffer-format "%b%t"
   "The format of the buffer name `denote-rename-buffer' should use.
 Thie value is a string that treats specially the following
 specifiers:
 
+- The %b inserts `denote-buffer-has-backlinks-string'.
 - The %t is the Denote TITLE of the file.
 - The %i is the Denote IDENTIFIER of the file.
 - The %d is the same as %i (DATE mnemonic).
@@ -91,20 +98,22 @@ buffer will be used, if available."
   "Parse the BUFFER through the `denote-rename-buffer-format'."
   (when-let ((file (buffer-file-name buffer))
              (type (denote-filetype-heuristics file)))
-    (string-trim
-     (format-spec denote-rename-buffer-format
-                  (list (cons ?t (cond
-                                  ((denote-retrieve-front-matter-title-value file type))
-                                  ((denote-retrieve-filename-title file))
-                                  (t  "")))
-                        (cons ?i (or (denote-retrieve-filename-identifier file) ""))
-                        (cons ?d (or (denote-retrieve-filename-identifier file) ""))
-                        (cons ?s (or (denote-retrieve-filename-signature file) ""))
-                        (cons ?k (if-let ((kws (denote-retrieve-front-matter-keywords-value file type)))
-                                     (denote-keywords-combine kws)
-                                   (or (denote-retrieve-filename-keywords file) "")))
-                        (cons ?% "%"))
-                  'delete))))
+    (let ((has-backlinks (not (zerop (length (denote-link-return-backlinks file))))))
+      (string-trim
+       (format-spec denote-rename-buffer-format
+                    (list (cons ?t (cond
+                                    ((denote-retrieve-front-matter-title-value file type))
+                                    ((denote-retrieve-filename-title file))
+                                    (t  "")))
+                          (cons ?b (if has-backlinks denote-buffer-has-backlinks-string ""))
+                          (cons ?i (or (denote-retrieve-filename-identifier file) ""))
+                          (cons ?d (or (denote-retrieve-filename-identifier file) ""))
+                          (cons ?s (or (denote-retrieve-filename-signature file) ""))
+                          (cons ?k (if-let ((kws (denote-retrieve-front-matter-keywords-value file type)))
+                                       (denote-keywords-combine kws)
+                                     (or (denote-retrieve-filename-keywords file) "")))
+                          (cons ?% "%"))
+                    'delete)))))
 
 (defun denote-rename-buffer (&optional buffer)
   "Rename current buffer or optional BUFFER with `denote-rename-buffer-format'.

--- a/denote.el
+++ b/denote.el
@@ -4015,6 +4015,10 @@ Also see `denote-link-return-links'."
              (id (denote-retrieve-filename-identifier-with-error current-file)))
     (delete current-file (denote--retrieve-files-in-xrefs id))))
 
+(defun denote--file-has-backlinks-p (file)
+  "Return whether or not there exists a file with a link to IDENTIFIER."
+  (not (zerop (length (denote-link-return-backlinks file)))))
+
 ;;;###autoload
 (defun denote-find-backlink ()
   "Use minibuffer completion to visit backlink to current file.


### PR DESCRIPTION
Hello Prot, thanks for all the work you've done with Denote!

Something I've wanted is some kind of indicator in the mode line that would alert me to the presence of backlinks to a file that I might want to investigate. I've put together a little prototype. It's clumsy; I hope you can give me some pointers on how to improve it. Here is what it does:

It adds `%b` to `denote-rename-buffer-format` which `denote-rename-buffer--format` will replace with `denote-buffer-has-backlinks-string` (defaults to `→ `) when the buffer has backlinks pointing to it.

The way it checks if a buffer has backlinks is possible more expensive than necessary; I call `(length (denote-link-return-backlinks file))` and check if the result is non-zero; that way I know for sure if a buffer has any backlinks Denote would recognize.

It seems to be working fine on my end; I'd be happy to hear any feedback. Let me know if this is welcome, and if it is, how to improve it.

Thanks!