### PR TITLE
Use absolute file path in denote-link--backlink-find-file

### DIFF
--- a/denote.el
+++ b/denote.el
@@ -4274,7 +4274,9 @@ major mode is not `org-mode' (or derived therefrom).  Consider using
 
 (defun denote-link--backlink-find-file (button)
   "Action for BUTTON to `find-file'."
-  (funcall denote-link-button-action (buffer-substring (button-start button) (button-end button))))
+  (funcall denote-link-button-action
+           (concat (denote-directory)
+                   (buffer-substring (button-start button) (button-end button)))))
 
 (defun denote-link--display-buffer (buf &optional action)
   "Run `display-buffer' on BUF using optional ACTION alist.


### PR DESCRIPTION
I think you mixed two things in commits 7f9d040 followed by 8701908. You removed a line `(setq-local default-directory ...)` and added a line `(setq-local denote-directory ...)`. Those 2 are unrelated and removing the first line causes issue #412.

In the end, it is a good thing that this line is removed though. It was probably there because we open buttons in backlinks buffers by calling `find-find` on the relative path. But we should try to always work with absolute paths in the code.

To fix #412, I made `denote-link--backlink-find-file` work with absolute paths instead of reintroducing the `(setq-local default-directory ...)` line. It is ready to be merged.