### PR TITLE
Rework denote-link-return-links (fix issue #416)

### DIFF
--- a/denote.el
+++ b/denote.el
@@ -4418,8 +4418,11 @@ non-nil value."
     (with-current-buffer (get-buffer-create backlinks-buffer)
       (erase-buffer)
       (denote-backlinks-mode)
-      ;; Set the `denote-directory' after enabling the major mode,
-      ;; otherwise its value gets overwritten.
+      ;; In the backlinks buffer, the values of variables set in a
+      ;; `.dir-locals.el` do not apply.  We need to set `denote-directory' in
+      ;; the backlinks buffer because the buttons depend on it.  Moreover, its
+      ;; value is overwritten after enabling the major mode, so it needs to be
+      ;; set after.
       (setq-local denote-directory dir)
       (setq overlay-arrow-position nil)
       (goto-char (point-min))

--- a/denote.el
+++ b/denote.el
@@ -3953,9 +3953,9 @@ function."
         (push (match-string-no-properties 1) matches)))
     matches))
 
-(defun denote-link--expand-identifiers (regexp files)
-  "Expand identifiers matching REGEXP in FILES into file paths."
-  (let ((files files)
+(defun denote-link--expand-identifiers (regexp)
+  "Expend identifiers matching REGEXP into file paths."
+  (let ((files (denote-directory-files))
         found-files)
     (dolist (file files)
       (dolist (i (denote-link--collect-identifiers regexp))
@@ -3989,11 +3989,10 @@ Also see `denote-link-return-backlinks'."
   (when-let ((current-file (or file (buffer-file-name)))
              ((denote-file-has-supported-extension-p current-file))
              (file-type (denote-filetype-heuristics current-file))
-             (regexp (denote--link-in-context-regexp file-type))
-             (files (denote-directory-files)))
+             (regexp (denote--link-in-context-regexp file-type)))
     (with-temp-buffer
       (insert-file-contents current-file)
-      (denote-link--expand-identifiers regexp files))))
+      (denote-link--expand-identifiers regexp))))
 
 (defalias 'denote-link-return-forelinks 'denote-link-return-links
   "Alias for `denote-link-return-links'.")

--- a/denote.el
+++ b/denote.el
@@ -3989,10 +3989,20 @@ Also see `denote-link-return-backlinks'."
   (when-let ((current-file (or file (buffer-file-name)))
              ((denote-file-has-supported-extension-p current-file))
              (file-type (denote-filetype-heuristics current-file))
-             (regexp (denote--link-in-context-regexp file-type)))
-    (with-temp-buffer
-      (insert-file-contents current-file)
-      (denote-link--expand-identifiers regexp))))
+             (regexp (denote--link-in-context-regexp file-type))
+             (files (denote-directory-files))
+             (file-identifiers
+              (with-temp-buffer
+                (insert-file-contents current-file)
+                (denote-link--collect-identifiers regexp)))
+             (file-identifiers-hash-table (make-hash-table :test 'equal)))
+    (dolist (id file-identifiers)
+      (puthash id t file-identifiers-hash-table))
+    (let ((found-files))
+      (dolist (file files)
+        (when (gethash (denote-retrieve-filename-identifier file) file-identifiers-hash-table)
+          (push file found-files)))
+      found-files)))
 
 (defalias 'denote-link-return-forelinks 'denote-link-return-links
   "Alias for `denote-link-return-links'.")


### PR DESCRIPTION
I have reworked `denote-link-return-links` to limit the use of `with-temp-buffer` to get what we need.

You will notice that I reverted your last change to `denote-link-return-links` because you added a new parameter to `denote-link--expand-identifiers`, but it is used in `denote-org-extras.el`. It must have broken something there. I have kept `denote-link--expand-identifiers` because it is used there, but maybe we can use `denote-link-return-links` instead and remove it.

`denote-link-return-links` should also be more efficient now. Previously, for each notes we looped through all links in the file.

This is ready to be merged. I will get to `denote-link--prepare-backlinks` tomorrow.