### PR TITLE
Make denote-rename-file parameters non-optional

### DIFF
--- a/README.org
+++ b/README.org
@@ -1490,9 +1490,14 @@ separated by a comma, else the ~crm-separator~).
 For all prompts, the ~denote-rename-file~ interprets an empty input as
 an instruction to remove that file name component. For example, if a
 =TITLE= prompt is available and =FILE= is =20240211T093531--some-title__keyword1.org=
-then it renames =FILE= to =20240211T093531__keyword1.org=. If a file
-name component is present, but there is no entry for it in
-~denote-prompts~, keep it as-is.
+then it renames =FILE= to =20240211T093531__keyword1.org=.
+
+In interactive use, if there is no entry for a file name
+component in `denote-prompts', keep it as-is.
+
+When called from Lisp, the special symbol `keep-current' can be
+used for the TITLE, KEYWORDS, SIGNATURE and DATE parameters to
+keep them as-is.
 
 [ NOTE: Please check with your minibuffer user interface how to
   provide an empty input. The Emacs default setup accepts the empty

--- a/denote.el
+++ b/denote.el
@@ -2980,7 +2980,9 @@ If `denote-rename-confirmations' does not contain
   "Rename FILE according to the other parameters.
 Parameters TITLE, KEYWORDS, SIGNATURE and DATE are as described
 in `denote-rename-file' and are assumed to be valid (TITLE and
-SIGNATURE are strings, KEYWORDS is a list, etc.).
+SIGNATURE are strings, KEYWORDS is a list, etc.).  The special
+symbol `keep-current' can be used for the TITLE, KEYWORDS,
+SIGNATURE and DATE parameters to keep the current value.
 
 This function only does the work necessary to rename a file
 according to its parameters.  In particular, it does not prompt
@@ -2994,7 +2996,12 @@ Respect `denote-rename-confirmations', `denote-save-buffers' and
          (file-type (denote-filetype-heuristics file))
          (current-title (or (denote-retrieve-front-matter-title-value file file-type) ""))
          (current-keywords (denote-extract-keywords-from-path file))
-         (keywords (denote-keywords-sort keywords))
+         (current-signature (or (denote-retrieve-filename-signature file) ""))
+         (title (if (eq title 'keep-current) current-title title))
+         (keywords (if (eq keywords 'keep-current) current-keywords (denote-keywords-sort keywords)))
+         (signature (if (eq signature 'keep-current) current-signature signature))
+         ;; 'keep-current is the same as nil because we do not currently allow the modification of the identifier
+         (date (if (eq date 'keep-current) nil date))
          (directory (file-name-directory file))
          (extension (file-name-extension file :include-period))
          ;; TODO: For now, we cannot change the identifier. We retrieve
@@ -3118,8 +3125,12 @@ remove that file name component.  For example, if a TITLE prompt
 is available and FILE is 20240211T093531--some-title__keyword1.org
 then rename FILE to 20240211T093531__keyword1.org.
 
-If a file name component is present, but there is no entry for it in
-`denote-prompts', keep it as-is.
+In interactive use, if there is no entry for a file name
+component in `denote-prompts', keep it as-is.
+
+When called from Lisp, the special symbol `keep-current' can be
+used for the TITLE, KEYWORDS, SIGNATURE and DATE parameters to
+keep them as-is.
 
 [ NOTE: Please check with your minibuffer user interface how to
   provide an empty input.  The Emacs default setup accepts the

--- a/denote.el
+++ b/denote.el
@@ -2994,7 +2994,7 @@ Respect `denote-rename-confirmations', `denote-save-buffers' and
 `denote-kill-buffers'."
   (let* ((initial-state (if (find-buffer-visiting file) 'visited 'not-visited))
          (file-type (denote-filetype-heuristics file))
-         (current-title (or (denote-retrieve-front-matter-title-value file file-type) ""))
+         (current-title (or (denote-retrieve-title-or-filename file file-type) ""))
          (current-keywords (denote-extract-keywords-from-path file))
          (current-signature (or (denote-retrieve-filename-signature file) ""))
          (title (if (eq title 'keep-current) current-title title))

--- a/denote.el
+++ b/denote.el
@@ -3061,7 +3061,7 @@ renaming commands."
     (list title keywords signature date)))
 
 ;;;###autoload
-(defun denote-rename-file (file &optional title keywords signature date)
+(defun denote-rename-file (file title keywords signature date)
   "Rename file and update existing front matter if appropriate.
 
 Always rename the file where it is located in the file system:


### PR DESCRIPTION
This does not affect the interactive `denote-rename-file`.

When called from lisp, one may believe that `(denote-rename-file
"some-file.org" "new-title")` will only rename the title. However, it also removes keywords and signature.

It may be confusing (see for example #405) to have them optional. I think it is better to make them mandatory for this reason.