### PR TITLE
Clean sluggification functions

### DIFF
--- a/README.org
+++ b/README.org
@@ -2131,8 +2131,7 @@ By default, Denote enforces other rules to file names through the user
 option ~denote-file-name-slug-functions~. These rules are applied to
 file names by default:
 
-+ What we count as "illegal characters" are removed.  The constant
-  ~denote-excluded-punctuation-regexp~ holds the relevant value.
++ What we count as "illegal characters" are removed.
 
 + Input for a file title is hyphenated.  The original value is
   preserved in the note's contents ([[#h:13218826-56a5-482a-9b91-5b6de4f14261][Front matter]]).
@@ -2213,13 +2212,16 @@ Denote. For example, we have this:
 ;; The original function for reference
 (defun denote-sluggify-title (str)
   "Make STR an appropriate slug for title."
-  (downcase (denote--slug-hyphenate (denote--slug-no-punct str))))
+  (downcase
+   (denote-slug-hyphenate
+    (replace-regexp-in-string "[][{}!@#$%^&*()+'\"?,.\|;:~`‘’“”/=]*" "" str))))
 
 ;; Our variant of the above, which does the same thing except from
 ;; downcasing the string.
 (defun my-denote-sluggify-title (str)
   "Make STR an appropriate slug for title."
-  (denote--slug-hyphenate (denote--slug-no-punct str)))
+  (denote-slug-hyphenate
+   (replace-regexp-in-string "[][{}!@#$%^&*()+'\"?,.\|;:~`‘’“”/=]*" "" str)))
 
 ;; Now we use our function to sluggify titles without affecting their
 ;; letter casing.
@@ -2271,24 +2273,20 @@ use the following in their Emacs configuration ([[#h:d375c6d2-92c7-425f-9d9d-219
 ;; except they remove all non-ASCII characters.
 (defun my-denote-sluggify-title (str)
   (downcase
-   (denote--slug-hyphenate
-    (denote--slug-no-punct
-     (denote-slug-keep-only-ascii str)))))
+   (denote-slug-hyphenate
+    (replace-regexp-in-string "[][{}!@#$%^&*()+'\"?,.\|;:~`‘’“”/=]*" ""
+                              (denote-slug-keep-only-ascii str)))))
 
 (defun my-denote-sluggify-signature (str)
   (downcase
-   (denote--slug-put-equals
-    (denote--slug-no-punct-for-signature
-     (denote-slug-keep-only-ascii str)
-     "-+"))))
+   (denote-slug-put-equals
+    (replace-regexp-in-string "[][{}!@#$%^&*()+'\"?,.\|;:~`‘’“”/-]*" ""
+                              (denote-slug-keep-only-ascii str)))))
 
 (defun my-denote-sluggify-keyword (str)
   (downcase
-   (replace-regexp-in-string
-    "-" ""
-    (denote--slug-hyphenate
-     (denote--slug-no-punct
-      (denote-slug-keep-only-ascii str))))))
+   (replace-regexp-in-string "[][{}!@#$%^&*()+'\"?,.\|;:~`‘’“”/_ -=]*" ""
+                             (denote-slug-keep-only-ascii str))))
 
 (defcustom denote-file-name-slug-functions
   '((title . my-denote-sluggify-title)
@@ -5094,18 +5092,6 @@ might change them without further notice.
 #+vindex: denote-keywords-regexp
 + Variable ~denote-keywords-regexp~ :: Regular expression to match the
   =KEYWORDS= field in a file name ([[#h:4e9c7512-84dc-4dfb-9fa9-e15d51178e5d][The file-naming scheme]]).
-
-#+vindex: denote-excluded-punctuation-regexp
-+ Variable ~denote-excluded-punctuation-regexp~ :: Punctionation that
-  is removed from file names.  We consider those characters illegal
-  for our purposes.
-
-#+vindex: denote-excluded-punctuation-extra-regexp
-+ Variable ~denote-excluded-punctuation-extra-regexp~ :: Additional
-  punctuation that is removed from file names.  This variable is for
-  advanced users who need to extend the ~denote-excluded-punctuation-regexp~.
-  Once we have a better understanding of what we should be omitting,
-  we will update things accordingly.
 
 #+findex: denote-identifier-p
 + Function ~denote-identifier-p~ :: Return non-nil if =IDENTIFIER=

--- a/tests/denote-test.el
+++ b/tests/denote-test.el
@@ -40,13 +40,11 @@
     (should (and (file-directory-p path)
                  (file-name-absolute-p path)))))
 
-(ert-deftest denote-test--denote--slug-no-punct ()
-  "Test that `denote--slug-no-punct' removes punctuation from the string.
-Concretely, replace with spaces anything that matches the
-`denote-excluded-punctuation-regexp' and
-`denote-excluded-punctuation-extra-regexp'."
-  (should (equal (denote--slug-no-punct "This is !@# test")
-                 "This is  test")))
+(ert-deftest denote-test--denote-sluggify-title ()
+  "Test that `denote-sluggify-title' removes punctuation from the string.
+Concretely, remove anything specified in `denote-sluggify-title'."
+  (should (equal (denote-sluggify-title "this-is-!@#test")
+                 "this-is-test")))
 
 (ert-deftest denote-test--denote-slug-keep-only-ascii ()
   "Test that `denote-slug-keep-only-ascii' removes non-ASCII characters."
@@ -54,11 +52,11 @@ Concretely, replace with spaces anything that matches the
            (denote-slug-keep-only-ascii "There are no-ASCII ： characters ｜ here 😀")
            "There are no-ASCII   characters   here  ")))
 
-(ert-deftest denote-test--denote--slug-hyphenate ()
-  "Test that `denote--slug-hyphenate' hyphenates the string.
+(ert-deftest denote-test--denote-slug-hyphenate ()
+  "Test that `denote-slug-hyphenate' hyphenates the string.
 Also replace multiple hyphens with a single one and remove any
 leading and trailing hyphen."
-  (should (equal (denote--slug-hyphenate "__  This is   a    test  __  ")
+  (should (equal (denote-slug-hyphenate "__  This is   a    test  __  ")
                  "This-is-a-test")))
 
 (ert-deftest denote-test--denote-sluggify ()
@@ -67,20 +65,20 @@ To sluggify is to (i) downcase, (ii) hyphenate, (iii) de-punctuate, and (iv) rem
   (should (equal (denote-sluggify 'title " ___ !~!!$%^ This iS a tEsT ++ ?? ")
                  "this-is-a-test")))
 
-(ert-deftest denote-test--denote--slug-put-equals ()
-  "Test that `denote--slug-put-equals' replaces spaces/underscores with =.
+(ert-deftest denote-test-denote--slug-put-equals ()
+  "Test that `denote-slug-put-equals' replaces spaces/underscores with =.
 Otherwise do the same as what is described in
-`denote-test--denote--slug-hyphenate'.
+`denote-test--denote-slug-hyphenate'.
 
 The use of the equals sign is for the SIGNATURE field of the
 Denote file name."
-  (should (equal (denote--slug-put-equals "__  This is   a    test  __  ")
+  (should (equal (denote-slug-put-equals "__  This is   a    test  __  ")
                  "This=is=a=test")))
 
 (ert-deftest denote-test--denote-sluggify-signature ()
   "Test that `denote-sluggify-signature' sluggifies the string for file signatures.
 This is like `denote-test--denote-sluggify', except that it also
-accounts for what we describe in `denote-test--denote--slug-put-equals'."
+accounts for what we describe in `denote-test--denote-slug-put-equals'."
   (should (equal (denote-sluggify-signature "--- ___ !~!!$%^ This -iS- a tEsT ++ ?? ")
                  "this=is=a=test")))
 


### PR DESCRIPTION
This pull request just cleans up the default sluggification before exposing it
to users. The behavior is unchanged.

Here are the changes:

- Remove `denote-excluded-punctuation-regexp`. It was a `defconst`, so users
  could not modify it anyway. It also ended up being used "as-is" only for the
  title sluggification. We worked around it in both the signature and keyword
  sluggification. So it was not very useful in the end.
- Deprecate `denote-excluded-punctuation-extra-regexp`. Users should customize
  `denote-file-name-slug-functions`. It should be easy now just looking at the
  default sluggification.
- Removed the extra-characters parameter from `denote--slug-no-punct`. It was
  one of the workaround mentionned in the point above to have signatures
  remove hyphens as well.

The character regexp is slightly different for all sluggification function
(title, signature, keyword). That is why it is simply hard-coded in their
respective function. I think it also makes it easier to read for a user that
wants to customize it.

In this end, `denote--slug-no-punct` was just calling
`replace-regexp-in-string`, so I just removed it.

I have updated the manual and tests as well, but I recommend against dwelling
too much on the signature and keyword sluggification in the manual. The reason
is that I don't except users will feel the need to customize them at all.

Sluggification is necessary in the case of the title because we want to type
the title in the prompt as it will appear in the front matter and the
sluggification should clean it up for the file name. On the other hand, the
signature and the keywords can be typed correctly directly in the prompt.
There is not really a need to have a function clean them up for the file name.
Moreover, keywords (and signature probably when we include it in the front
matter) are sluggified in the front matter as well. Just mentionning
sluggification of signature/keyword as a possibility in the docstring of
`denote-file-name-slug-functions` seems enough to me.