### PR TITLE
Add denote-file-type function

### DIFF
--- a/denote.el
+++ b/denote.el
@@ -2775,28 +2775,31 @@ See the format of `denote-file-types'."
            (string-match-p "\\`\\*Org Note\\*" (buffer-name))
            (null buffer-file-name))))
 
-(defun denote-filetype-heuristics (file)
-  "Return likely file type of FILE.
-If in the process of `org-capture', consider the file type to be that of
-Org.  Otherwise, use the file extension to detect the file type of FILE.
+(defun denote-file-type (file)
+  "Use the file extension to detect the file type of FILE.
 
 If more than one file type correspond to this file extension, use the
 first file type for which the :title-key-regexp in `denote-file-types'
 matches in the file.
 
 Return nil if the file type is not recognized."
+  (when-let ((extension (denote-get-file-extension-sans-encryption file))
+             (types (denote--file-types-with-extension extension)))
+    (if (= (length types) 1)
+        (caar types)
+      (or (car (seq-find
+                (lambda (type)
+                  (denote--regexp-in-file-p (plist-get (cdr type) :title-key-regexp) file))
+                types))
+          (caar types)))))
+
+(defun denote-filetype-heuristics (file)
+  "Return likely file type of FILE.
+If in the process of `org-capture', consider the file type to be that of
+Org.  Otherwise, use the function `denote-file-type' to return the type."
   (cond
    ((denote--file-type-org-extra-p) 'org)
-   (file
-    (when-let ((extension (denote-get-file-extension-sans-encryption file))
-               (types (denote--file-types-with-extension extension)))
-      (if (= (length types) 1)
-          (caar types)
-        (or (car (seq-find
-                  (lambda (type)
-                    (denote--regexp-in-file-p (plist-get (cdr type) :title-key-regexp) file))
-                  types))
-            (caar types)))))))
+   (file (denote-file-type file))))
 
 (defun denote--file-attributes-time (file)
   "Return `file-attribute-modification-time' of FILE as identifier."


### PR DESCRIPTION
In this pull request, I just extracted the ***function*** `denote-file-type` (not to
be confused with the ***variable***) from `denote-filetype-heuristics` as
suggested in #284.

There may be value in having this function that just retrieves the file type
of a note, without the extra checking that `denote-filetype-heuristics` does
for special org buffers.

I believe that even our code should use the `denote-file-type` function
instead of `denote-filetype-heuristics` in a few places, but I have not
changed anything about that here. This can be done later, if needed.

You may want to credit mentalisttraceur for this change in the release
notes. See #284.

This also closes #284.