### PR TITLE
Revert "Use file-truename in denote-filename-is-note-p and denote--di…

### DIFF
--- a/denote.el
+++ b/denote.el
@@ -1066,8 +1066,7 @@ extensions are those implied by the variable `denote-file-type'."
 For our purposes, its path must be part of the variable
 `denote-directory', it must have a Denote identifier in its name, and
 use one of the extensions implied by the variable `denote-file-type'."
-  (and (string-prefix-p (file-truename (denote-directory))
-                        (file-truename (expand-file-name filename)))
+  (and (string-prefix-p (denote-directory) (expand-file-name filename))
        (denote-file-has-identifier-p filename)
        (denote-file-has-supported-extension-p filename)))
 
@@ -2025,8 +2024,8 @@ TEMPLATE, and SIGNATURE should be valid for note creation."
 (defun denote--dir-in-denote-directory-p (directory)
   "Return non-nil if DIRECTORY is in variable `denote-directory'."
   (and directory
-       (string-prefix-p (file-truename (denote-directory))
-                        (file-truename (expand-file-name directory)))))
+       (string-prefix-p (denote-directory)
+                        (expand-file-name directory))))
 
 (defun denote--valid-file-type (filetype)
   "Return a valid filetype symbol given the argument FILETYPE.


### PR DESCRIPTION
I am reverting commit 5fade0c because it will break Denote for some users.

If one's `denote-directory` contains symlink subdirectories (that link to
directories outside `denote-directory`), then some Denote features for those
notes will not work anymore.

We should not use `file-truename` because those directories will become
"outside" `denote-directory`. I don't see a non-costly way of doing this
validation. So I just recommend this warning in the manual:

```
If your `denote-directory` or its subdirectories involve symbolic links, make
sure that you access them using those links (and that
`find-file-visit-truename` is nil). Otherwise, Denote features will not work.
```

For the same reason, we should remove `file-truename` to fix related issue
#346 (with the same warning as above). I will do a separate pull request.