### PR TITLE
Fix issue reported in #435

### DIFF
--- a/README.org
+++ b/README.org
@@ -2401,7 +2401,7 @@ use the following in their Emacs configuration ([[#h:d375c6d2-92c7-425f-9d9d-219
 
 (defun my-denote-sluggify-keyword (str)
   (downcase
-   (replace-regexp-in-string "[][{}!@#$%^&*()+'\"?,.\|;:~`‘’“”/_ -=]*" ""
+   (replace-regexp-in-string "[][{}!@#$%^&*()+'\"?,.\|;:~`‘’“”/_ =-]*" ""
                              (denote-slug-keep-only-ascii str))))
 
 (defcustom denote-file-name-slug-functions

--- a/denote.el
+++ b/denote.el
@@ -1026,7 +1026,7 @@ they are used as the keywords separator in file names."
 (defun denote-sluggify-keyword (str)
   "Sluggify STR while joining separate words."
   (downcase
-   (replace-regexp-in-string "[][{}!@#$%^&*()+'\"?,.\|;:~`‘’“”/_ -=]*" "" str)))
+   (replace-regexp-in-string "[][{}!@#$%^&*()+'\"?,.\|;:~`‘’“”/_ =-]*" "" str)))
 
 (make-obsolete
  'denote-sluggify-and-join


### PR DESCRIPTION
This should fix the issue reported by ssl19 in #435 about digits being sluggified in keywords.

The hyphen character should appear last in a character alternative.