### PR TITLE
Remove redundant "Denote" item from denote--menu-contents

### DIFF
--- a/denote.el
+++ b/denote.el
@@ -3776,8 +3776,7 @@ This command is meant to be used from a Dired buffer."
 ;;;;; Define menu
 
 (defvar denote--menu-contents
-  '("Denote"
-    ["Create a note" denote
+  '(["Create a note" denote
      :help "Create a new note in the `denote-directory'"]
     ["Create a note with given file type" denote-type
      :help "Create a new note with a given file type in the `denote-directory'"]


### PR DESCRIPTION
This pull request removes the redundant "Denote" item from the `denote--menu-contents` variable. 

This item surprisingly does not do anything when clicked, so all the more reason for it to be removed.