### PR TITLE
Fix unused let-bound variable warnings

### DIFF
--- a/denote-org-extras.el
+++ b/denote-org-extras.el
@@ -667,10 +667,10 @@ Used by `org-dblock-update' with PARAMS provided by the dynamic block."
 (defun denote-org-extras-dblock--get-file-contents-as-heading (file add-links)
   "Insert the contents of Org FILE, formatting the #+title as a heading.
 With optional ADD-LINKS, make the title link to the original file."
-  (when-let ((_ (denote-file-is-note-p file))
+  (when-let (((denote-file-is-note-p file))
              (identifier (denote-retrieve-filename-identifier file))
              (file-type (denote-filetype-heuristics file))
-             (_ (eq file-type 'org)))
+             ((eq file-type 'org)))
     (with-temp-buffer
       (let ((beginning-of-contents (point))
             title

--- a/denote.el
+++ b/denote.el
@@ -4355,8 +4355,8 @@ Implementation based on the function `org-activate-links'."
   "Return the Denote identifier at point or optional POINT."
   (when-let ((position (or point (point)))
              (face-at-point (get-text-property position 'face))
-             (_ (or (eq face-at-point 'denote-faces-link)
-                    (member 'denote-faces-link face-at-point))))
+             ((or (eq face-at-point 'denote-faces-link)
+                  (member 'denote-faces-link face-at-point))))
     (or (get-text-property position 'denote-link-id)
         (when-let ((link-data (get-text-property position 'htmlize-link))
                    (link (cadr link-data)))


### PR DESCRIPTION
I noticed some warnings pop up during a reinstallation of Denote and went and fixed them.

Here are the errors for reference:

```
⛔ Warning (comp): denote.el:4347:15: Warning: variable ‘_’ not left unused
⛔ Warning (comp): denote-org-extras.el:640:15: Warning: variable ‘_’ not left unused
⛔ Warning (comp): denote-org-extras.el:637:15: Warning: variable ‘_’ not left unused
```

Unlike `pcase` which holds a special meaning for `_`, there's no way to mark a let-bound variable as ignored but we can omit the SYMBOL name from the VARLIST and the `when-let` expression will still evaluate correctly.