### PR TITLE
Some cleanup and fix `denote-link-dired-marked-notes`

### DIFF
--- a/denote.el
+++ b/denote.el
@@ -4719,10 +4719,9 @@ This command is meant to be used from a Dired buffer."
       (user-error "The buffer's file type is not recognized by Denote")))
   (when (y-or-n-p (format "Create links at point in %s?" buffer))
     (with-current-buffer buffer
-      (insert (denote-link--prepare-links
-               files
-               (denote-filetype-heuristics (buffer-file-name))
-               id-only)))))
+      (denote-link--insert-links files
+                                 (denote-filetype-heuristics (buffer-file-name))
+                                 id-only))))
 
 ;;;;; Define menu
 

--- a/denote.el
+++ b/denote.el
@@ -4666,13 +4666,13 @@ inserts links with just the identifier."
 ;;;;; Links from Dired marks
 
 ;; NOTE 2022-07-21: I don't think we need a history for this one.
-(defun denote-link--buffer-prompt (buffers)
-  "Select buffer from BUFFERS visiting Denote notes."
-  (let ((buffer-file-names (mapcar #'denote-get-file-name-relative-to-denote-directory buffers)))
+(defun denote-link--buffer-file-prompt (buffer-file-names)
+  "Select file from BUFFER-FILE-NAMES of Denote notes."
+  (let ((relative-buffer-file-names (mapcar #'denote-get-file-name-relative-to-denote-directory buffer-file-names)))
     (concat (denote-directory)
             (completing-read
-             "Select note buffer: "
-             (denote--completion-table 'buffer buffer-file-names)
+             "Select note file buffer: "
+             (denote--completion-table 'buffer relative-buffer-file-names)
              nil t))))
 
 (defun denote-link--map-over-notes ()
@@ -4709,7 +4709,7 @@ This command is meant to be used from a Dired buffer."
         ((eq (length file-names) 1)
          (car file-names))
         (t
-         (denote-link--buffer-prompt file-names)))))
+         (denote-link--buffer-file-prompt file-names)))))
     current-prefix-arg)
    dired-mode)
   (when (null files)

--- a/denote.el
+++ b/denote.el
@@ -2046,9 +2046,7 @@ TEMPLATE, and SIGNATURE should be valid for note creation."
 
 (defun denote--dir-in-denote-directory-p (directory)
   "Return non-nil if DIRECTORY is in variable `denote-directory'."
-  (and directory
-       (string-prefix-p (denote-directory)
-                        (expand-file-name directory))))
+  (string-prefix-p (denote-directory) (expand-file-name directory)))
 
 (defun denote--valid-file-type (filetype)
   "Return a valid filetype symbol given the argument FILETYPE.

--- a/denote.el
+++ b/denote.el
@@ -4676,8 +4676,7 @@ inserts links with just the identifier."
 
 (defun denote-link--map-over-notes ()
   "Return list of `denote-file-is-note-p' from Dired marked items."
-  (when (denote--dir-in-denote-directory-p default-directory)
-    (seq-filter #'denote-file-is-note-p (dired-get-marked-files))))
+  (seq-filter #'denote-file-is-note-p (dired-get-marked-files)))
 
 ;;;###autoload
 (defun denote-link-dired-marked-notes (files buffer &optional id-only)

--- a/denote.el
+++ b/denote.el
@@ -4668,11 +4668,12 @@ inserts links with just the identifier."
 ;; NOTE 2022-07-21: I don't think we need a history for this one.
 (defun denote-link--buffer-prompt (buffers)
   "Select buffer from BUFFERS visiting Denote notes."
-  (let ((buffer-file-names (mapcar #'file-name-nondirectory buffers)))
-    (completing-read
-     "Select note buffer: "
-     (denote--completion-table 'buffer buffer-file-names)
-     nil t)))
+  (let ((buffer-file-names (mapcar #'denote-get-file-name-relative-to-denote-directory buffers)))
+    (concat (denote-directory)
+            (completing-read
+             "Select note buffer: "
+             (denote--completion-table 'buffer buffer-file-names)
+             nil t))))
 
 (defun denote-link--map-over-notes ()
   "Return list of `denote-file-is-note-p' from Dired marked items."


### PR DESCRIPTION
I removed the nil checking of `denote--dir-in-denote-directory-p`. It is not
needed. It is an internal function. Calling it with nil would be a mistake. It
seems like it came from one of my commits (34daa52) where we were using a
`when-let`. It does not look like it was introduced to fix a bug. If there is,
we should ensure that we call it with a non-nil value.

I removed the condition in `denote-link--map-over-notes`. If one open the
parent of denote-directory in Dired and use "i" on the denote-directory, the
notes of this subdirectory will be listed in the current Dired buffer. The
user can mark them and call denote-link-dired-marked-notes. Previously, this
would fail because the current Dired buffer is not in denote-directory.

Speaking of `denote-link-dired-marked-notes`, since commit d942333, it is
broken because the `insert` line still expects `denote-link--prepare-links` to
return a string, but it now returns a list of strings. I fixed it.