### PR TITLE
Cleanup of date handling function and more

### DIFF
--- a/README.org
+++ b/README.org
@@ -5751,8 +5751,8 @@ might change them without further notice.
 
 #+findex: denote-retrieve-filename-identifier
 + Function ~denote-retrieve-filename-identifier~ :: Extract identifier
-  from =FILE= name, if present, else return nil.  To create a new one, refer to the
-  ~denote-create-unique-file-identifier~ function.
+  from =FILE= name, if present, else return nil.  To create a new one
+  from a date, refer to the ~denote-get-identifier~ function.
 
 #+findex: denote-retrieve-filename-title
 + Function ~denote-retrieve-filename-title~ ::  Extract Denote title
@@ -5777,24 +5777,6 @@ might change them without further notice.
 + Function ~denote-get-identifier~ :: Convert =DATE= into a Denote
   identifier using ~denote-id-format~. If =DATE= is nil, return an empty
   string as the identifier.
-
-#+findex: denote-create-unique-file-identifier
-+ Function ~denote-create-unique-file-identifier~ :: Create a new unique
-  =FILE= identifier.  Test that the identifier is unique among
-  =USED-IDS=.  The conditions are as follows:
-
-  - If =DATE= is non-nil, invoke ~denote-prompt-for-date-return-id~.
-
-  - If =DATE= is nil, use the file attributes to determine the last
-    modified date and format it as an identifier.
-
-  - As a fallback, derive an identifier from the current time.
-
-  With optional =USED-IDS= as nil, test that the identifier is unique
-  among all files and buffers in variable ~denote-directory~.
-
-  To only return an existing identifier, refer to the function
-  ~denote-retrieve-filename-identifier~.
 
 #+findex: denote-retrieve-front-matter-title-value
 + Function ~denote-retrieve-front-matter-title-value~ :: Return title value from

--- a/README.org
+++ b/README.org
@@ -5577,12 +5577,6 @@ might change them without further notice.
   or ~date-to-time~ .Those functions signal an error if =DATE= is a
   value they do not recognise. If =DATE= is nil, return nil.
 
-#+findex: denote-parse-date
-+ Function ~denote-parse-date~ :: Return =DATE= as an appropriate
-  value for the ~denote~ command. Pass =DATE= through
-  ~denote-valid-date-p~ and use its return value. If either that or
-  =DATE= is nil, return ~current-time~.
-
 #+findex: denote-directory
 + Function ~denote-directory~ :: Return path of the variable
   ~denote-directory~ as a proper directory, also because it accepts a

--- a/README.org
+++ b/README.org
@@ -5718,8 +5718,9 @@ might change them without further notice.
   the case when returning the value of the variable ~denote-directory~).
   =DIR-PATH= cannot be nil or an empty string.
 
-  =ID= is a string holding the identifier of the note. It cannot be
-  nil or an empty string and must match ~denote-id-regexp~.
+  =ID= is a string holding the identifier of the note. It can be an
+  empty string, in which case its respective file name component is
+  not added to the base file name.
 
   =DIR-PATH= and =ID= form the base file name.
 

--- a/README.org
+++ b/README.org
@@ -5775,8 +5775,8 @@ might change them without further notice.
 
 #+findex: denote-get-identifier
 + Function ~denote-get-identifier~ :: Convert =DATE= into a Denote
-  identifier using ~denote-id-format~. =DATE= is parsed by
-  ~denote-valid-date-p~. If =DATE= is nil, use the current time.
+  identifier using ~denote-id-format~. If =DATE= is nil, return an empty
+  string as the identifier.
 
 #+findex: denote-create-unique-file-identifier
 + Function ~denote-create-unique-file-identifier~ :: Create a new unique

--- a/denote-journal-extras.el
+++ b/denote-journal-extras.el
@@ -150,9 +150,9 @@ date selection module.
 
 When called from Lisp DATE is a string and has the same format as
 that covered in the documentation of the `denote' function.  It
-is internally processed by `denote-parse-date'."
+is internally processed by `denote-valid-date-p'."
   (interactive (list (when current-prefix-arg (denote-date-prompt))))
-  (let ((internal-date (denote-parse-date date))
+  (let ((internal-date (or (denote-valid-date-p date) (current-time)))
         (denote-directory (denote-journal-extras-directory)))
     (denote
      (denote-journal-extras-daily--title-format internal-date)
@@ -163,7 +163,7 @@ is internally processed by `denote-parse-date'."
 
 (defun denote-journal-extras--entry-today (&optional date)
   "Return list of files matching a journal for today or optional DATE.
-DATE has the same format as that returned by `denote-parse-date'."
+DATE has the same format as that returned by `denote-valid-date-p'."
   (let* ((identifier (format "%sT[0-9]\\{6\\}" (format-time-string "%Y%m%d" date)))
          (files (denote-directory-files identifier))
          (keyword (concat "_" (regexp-quote denote-journal-extras-keyword))))
@@ -183,12 +183,12 @@ DATE has the same format as that returned by `denote-parse-date'."
 With optional DATE, do it for that date, else do it for today.  DATE is
 a string and has the same format as that covered in the documentation of
 the `denote' function.  It is internally processed by
-`denote-parse-date'.
+`denote-valid-date-p'.
 
 If there are multiple journal entries for the date, prompt for one among
 them using minibuffer completion.  If there is only one, return it.  If
 there is no journal entry, create it."
-  (let* ((internal-date (denote-parse-date date))
+  (let* ((internal-date (or (denote-valid-date-p date) (current-time)))
          (files (denote-journal-extras--entry-today internal-date)))
     (cond
      ((length> files 1)
@@ -218,7 +218,7 @@ date selection module.
 
 When called from Lisp, DATE is a string and has the same format
 as that covered in the documentation of the `denote' function.
-It is internally processed by `denote-parse-date'."
+It is internally processed by `denote-valid-date-p'."
   (interactive
    (list
     (when current-prefix-arg
@@ -242,7 +242,7 @@ date selection module.
 
 When called from Lisp, DATE is a string and has the same format
 as that covered in the documentation of the `denote' function.
-It is internally processed by `denote-parse-date'.
+It is internally processed by `denote-valid-date-p'.
 
 With optional ID-ONLY as a prefix argument create a link that
 consists of just the identifier.  Else try to also include the

--- a/denote.el
+++ b/denote.el
@@ -2227,7 +2227,7 @@ If DATE is nil or an empty string, return nil."
         ((and (or (numberp date) (listp date))
               (decode-time date))
          date)
-        (t
+        (t ; non-empty strings (e.g. "2024-01-01", "2024-01-01 12:00", etc.)
          (date-to-time (denote--date-add-current-time date)))))
 
 (defun denote-parse-date (date)

--- a/denote.el
+++ b/denote.el
@@ -2085,8 +2085,6 @@ which case it is not added to the base file name."
     (error "DIR-PATH must not be an empty string"))
    ((not (string-suffix-p "/" dir-path))
     (error "DIR-PATH does not end with a / as directories ought to"))
-   ((null id)
-    (error "ID must not be nil"))
    ((string-empty-p id)
     (error "ID must not be an empty string"))
    ((not (string-match-p denote-id-regexp id))

--- a/denote.el
+++ b/denote.el
@@ -2084,9 +2084,7 @@ which case it is not added to the base file name."
    ((string-empty-p dir-path)
     (error "DIR-PATH must not be an empty string"))
    ((not (string-suffix-p "/" dir-path))
-    (error "DIR-PATH does not end with a / as directories ought to"))
-   ((not (string-match-p denote-id-regexp id))
-    (error "ID `%s' does not match `denote-id-regexp'" id)))
+    (error "DIR-PATH does not end with a / as directories ought to")))
   (let ((file-name "")
         (components (seq-union denote-file-name-components-order
                                '(identifier signature title keywords))))

--- a/denote.el
+++ b/denote.el
@@ -1559,7 +1559,10 @@ Consult the `denote-file-types' for how this is used."
   "Extract date object from front matter DATE-STRING.
 
 Consult the `denote-file-types' for how this is used."
-  (date-to-time (denote-trim-whitespace date-string)))
+  (let ((date-string (denote-trim-whitespace date-string)))
+    (if (string-empty-p date-string)
+        nil
+      (date-to-time date-string))))
 
 (defvar denote-file-types
   '((org
@@ -2125,6 +2128,8 @@ which case it is not added to the base file name."
   "Expand DATE in an appropriate format for FILE-TYPE."
   (let ((format denote-date-format))
     (cond
+     ((null date)
+      "")
      (format
       (format-time-string format date))
      ((when-let* ((fn (denote--date-value-function file-type)))
@@ -2950,7 +2955,8 @@ If a buffer is visiting the file, its name is updated."
 The TITLE, KEYWORDS, ID, SIGNATURE, and FILE-TYPE are passed from the
 renaming command and are used to construct a new front matter block if
 appropriate."
-  (when-let* ((new-front-matter (denote--format-front-matter title (date-to-time id) keywords id signature file-type)))
+  (when-let* ((date (if (string-empty-p id) nil (date-to-time id)))
+              (new-front-matter (denote--format-front-matter title date keywords id signature file-type)))
     (with-current-buffer (find-file-noselect file)
       (goto-char (point-min))
       (insert new-front-matter))))

--- a/denote.el
+++ b/denote.el
@@ -922,13 +922,13 @@ The note's ID is derived from the date and time of its creation.")
 (defconst denote-id-regexp "\\([0-9]\\{8\\}\\)\\(T[0-9]\\{6\\}\\)"
   "Regular expression to match `denote-id-format'.")
 
-(defconst denote-signature-regexp "==\\([^.]*?\\)\\(==.*\\|--.*\\|__.*\\|@@\\([0-9]\\{8\\}\\)\\(T[0-9]\\{6\\}\\)\\|\\|\\..*\\)*$"
+(defconst denote-signature-regexp "==\\([^.]*?\\)\\(==.*\\|--.*\\|__.*\\|@@.*\\|\\..*\\)*$"
   "Regular expression to match the SIGNATURE field in a file name.")
 
-(defconst denote-title-regexp "--\\([^.]*?\\)\\(==.*\\|__.*\\|@@\\([0-9]\\{8\\}\\)\\(T[0-9]\\{6\\}\\)\\|\\|\\..*\\)*$"
+(defconst denote-title-regexp "--\\([^.]*?\\)\\(==.*\\|__.*\\|@@.*\\|\\..*\\)*$"
   "Regular expression to match the TITLE field in a file name.")
 
-(defconst denote-keywords-regexp "__\\([^.]*?\\)\\(==.*\\|--.*\\|__.*\\|@@\\([0-9]\\{8\\}\\)\\(T[0-9]\\{6\\}\\)\\|\\..*\\)*$"
+(defconst denote-keywords-regexp "__\\([^.]*?\\)\\(==.*\\|--.*\\|__.*\\|@@.*\\|\\..*\\)*$"
   "Regular expression to match the KEYWORDS field in a file name.")
 
 (make-obsolete-variable

--- a/denote.el
+++ b/denote.el
@@ -2213,6 +2213,11 @@ where the former does not read dates without a time component."
   'denote-valid-date-p
   "2.3.0")
 
+(define-obsolete-function-alias
+  'denote-parse-date
+  'denote-valid-date-p
+  "3.2.0")
+
 (defun denote-valid-date-p (date)
   "Return DATE as a valid date.
 A valid DATE is a value that can be parsed by either
@@ -2229,13 +2234,6 @@ If DATE is nil or an empty string, return nil."
          date)
         (t ; non-empty strings (e.g. "2024-01-01", "2024-01-01 12:00", etc.)
          (date-to-time (denote--date-add-current-time date)))))
-
-(defun denote-parse-date (date)
-  "Return DATE as an appropriate value for the `denote' command.
-Pass DATE through `denote-valid-date-p' and use its return value.
-If either that or DATE is nil or an empty string, return
-`current-time'."
-  (or (denote-valid-date-p date) (current-time)))
 
 (defun denote--id-to-date (identifier)
   "Convert IDENTIFIER string to YYYY-MM-DD."
@@ -2510,7 +2508,7 @@ instead of that of the parameter."
          (title (or title ""))
          (file-type (denote--valid-file-type (or file-type denote-file-type)))
          (keywords (denote-keywords-sort keywords))
-         (date (denote-parse-date date))
+         (date (denote-valid-date-p date))
          (directory (if (and directory (denote--dir-in-denote-directory-p directory))
                         (file-name-as-directory directory)
                       (denote-directory)))
@@ -2559,6 +2557,11 @@ When called from Lisp, all arguments are optional.
   (interactive (denote--creation-get-note-data-from-prompts))
   (pcase-let* ((`(,title ,keywords ,file-type ,directory ,date ,template ,signature)
                 (denote--creation-prepare-note-data title keywords file-type directory date template signature))
+               ;; TODO: When the following line is removed, Denote should
+               ;; create a note without a date/id.  However, some features
+               ;; will not completely work (fontification, linking, etc.).
+               ;; They need to be reviewed before making this available.
+               (date (or date (current-time)))
                (id (denote--find-first-unused-id (denote-get-identifier date)))
                (note-path (denote--prepare-note title keywords date id directory file-type template signature)))
     (denote--keywords-add-to-history keywords)

--- a/denote.el
+++ b/denote.el
@@ -2539,7 +2539,8 @@ When called from Lisp, all arguments are optional.
                ;; will not completely work (fontification, linking, etc.).
                ;; They need to be reviewed before making this available.
                (date (or date (current-time)))
-               (id (denote--find-first-unused-id (denote-get-identifier date)))
+               (id (denote-get-identifier date))
+               (id (if (string-empty-p id) id (denote--find-first-unused-id id)))
                (note-path (denote--prepare-note title keywords date id directory file-type template signature)))
     (denote--keywords-add-to-history keywords)
     (run-hooks 'denote-after-new-note-hook)
@@ -5163,7 +5164,9 @@ Consult the manual for template samples."
                 (denote--creation-get-note-data-from-prompts))
                (`(,title ,keywords _ ,directory ,date ,template ,signature)
                 (denote--creation-prepare-note-data title keywords 'org directory date template signature))
-               (id (denote--find-first-unused-id (denote-get-identifier date)))
+               (date (or date (current-time)))  ; See comment in `denote' command.
+               (id (denote-get-identifier date))
+               (id (if (string-empty-p id) id (denote--find-first-unused-id id)))
                (front-matter (denote--format-front-matter title date keywords id signature 'org))
                (template-string (cond ((stringp template) template)
                                       ((functionp template) (funcall template))

--- a/denote.el
+++ b/denote.el
@@ -2085,8 +2085,6 @@ which case it is not added to the base file name."
     (error "DIR-PATH must not be an empty string"))
    ((not (string-suffix-p "/" dir-path))
     (error "DIR-PATH does not end with a / as directories ought to"))
-   ((string-empty-p id)
-    (error "ID must not be an empty string"))
    ((not (string-match-p denote-id-regexp id))
     (error "ID `%s' does not match `denote-id-regexp'" id)))
   (let ((file-name "")

--- a/denote.el
+++ b/denote.el
@@ -3140,7 +3140,7 @@ Respect `denote-rename-confirmations', `denote-save-buffers' and
             (denote-rewrite-front-matter new-name title keywords file-type)
           (when (denote-add-front-matter-prompt new-name)
             (denote--add-front-matter new-name title keywords date id signature file-type))))
-      (when denote--used-ids
+      (when (and denote--used-ids (not (string-empty-p id)))
         (puthash id t denote--used-ids))
       (denote--handle-save-and-kill-buffer 'rename new-name initial-state)
       (run-hooks 'denote-after-rename-file-hook))

--- a/denote.el
+++ b/denote.el
@@ -1841,7 +1841,7 @@ is a list of strings.  FILETYPE is one of the values of variable
 `denote-file-type'."
   (let* ((fm (denote--front-matter filetype))
          (title-string (funcall (denote--title-value-function filetype) title))
-         (date-string (denote--date date filetype))
+         (date-string (denote--format-front-matter-date date filetype))
          (keywords-string (funcall (denote--keywords-value-function filetype) (denote-sluggify-keywords keywords)))
          (id-string (funcall (denote--identifier-value-function filetype) id))
          (signature-string (funcall (denote--signature-value-function filetype) (denote-sluggify-signature signature))))
@@ -2144,7 +2144,7 @@ which case it is not added to the base file name."
   "Format DATE according to ISO 8601 standard."
   (format-time-string "%F" date))
 
-(defun denote--date (date file-type)
+(defun denote--format-front-matter-date (date file-type)
   "Expand DATE in an appropriate format for FILE-TYPE."
   (let ((format denote-date-format))
     (cond

--- a/denote.el
+++ b/denote.el
@@ -2061,8 +2061,9 @@ forward slash (the function `denote-directory' makes sure this is
 the case when returning the value of the variable `denote-directory').
 DIR-PATH cannot be nil or an empty string.
 
-ID is a string holding the identifier of the note.  It cannot be
-nil or an empty string and must match `denote-id-regexp'.
+ID is a string holding the identifier of the note.  It can be an
+empty string, in which case its respective file name component is
+not added to the base file name.
 
 DIR-PATH and ID form the base file name.
 

--- a/tests/denote-test.el
+++ b/tests/denote-test.el
@@ -395,11 +395,9 @@ does not involve the time zone."
 
 (ert-deftest denote-test--denote-get-identifier ()
   "Test that `denote-get-identifier' returns an identifier."
-  (should (and (equal (denote-get-identifier) (format-time-string denote-id-format (current-time)))
-               (equal (denote-get-identifier "2024-02-01 10:34") "20240201T103400")
+  (should (and (equal (denote-get-identifier nil) "")
                (equal (denote-get-identifier 1705644188) "20240119T080308")
-               (equal (denote-get-identifier '(26026 4251)) "20240119T080307")))
-  (should-error (denote-get-identifier "Invalid date")))
+               (equal (denote-get-identifier '(26026 4251)) "20240119T080307"))))
 
 (ert-deftest denote-test--denote-retrieve-filename-identifier ()
   "Test that `denote-retrieve-filename-identifier' returns only the identifier."


### PR DESCRIPTION
This pull request is mostly about date handling, but there are a few other
cleanups as well.

- `denote-get-identifier`: The `date` parameter is no longer optional. This a
  a function (not a command) and we only used it without a date once. Also, it
  does not check `denote-valid-date-p` anymore. Within the scope of
  `denote-get-identifier`, it is too late for this validation. The callers
  should have done this. We almost always did this already. I patched the only
  place where we did not.

- `denote-valid-date-p`: Unchanged. This is the function that returns a valid
  date object (or nil). It is good!

- `denote--date`: Renamed to `denote--format-front-matter-date`.

- `denote-parse-date`: Obsoleted. It was just like `denote-valid-date-p`, but
  it converted nil dates to `(current-time)`. I think this is not really
  desirable. See below.

- `denote-create-unique-file-identifier`: Obsoleted. We used it only inside
  `denote--rename-file`, but it was not really the best place. We don't need
  it in the end.

- I removed some limitations of `denote-format-file-name`. This is a general
  function. As such, it is good that it can do things that we don't use
  (yet). For example, accept identifiers of different formats or empty
  identifiers. It is easily able to handle these cases. We enforce the format
  of the identifiers in other parts of the code, as necessary.

- I removed the id format checking from the
  `denote-{title/signature/keywords}-regexp`. We don't need to check the
  format of the identifier here. In fact, if we do, it would mean that a file
  "--title@@123.org" would yield the title "title@@123". We probably want to
  stop parsing any component when another delimiter is found. At some point,
  we may be more flexible with identifiers formats.

### Internal dates

Internally, we now always work with date objects (possibly `(current-time)`).
A nil value now always means "no date".

"No date" is still not publicly supported, i.e. Denote still always create notes
with a date/id. However, internally, functions are now capable of working with
nil dates. They do not need to be limited.