### PR TITLE
Refactored `denote-rewrite-front-matter`

### DIFF
--- a/README.org
+++ b/README.org
@@ -5901,11 +5901,11 @@ might change them without further notice.
 #+findex: denote-rewrite-front-matter
 + Function ~denote-rewrite-front-matter~ :: Rewrite front matter of
   note after ~denote-rename-file~ (or related) The =FILE=, =TITLE=,
-  =KEYWORDS=, and =FILE-TYPE= arguments are given by the renaming
-  command and are used to construct new front matter values if
-  appropriate. If ~denote-rename-confirmations~ contains
-  ~rewrite-front-matter~, prompt to confirm the rewriting of the front
-  matter. Otherwise produce a ~y-or-n-p~ prompt to that effect.
+  =KEYWORDS=, =SIGNATURE=, =DATE=, =IDENTIFIER=, and =FILE-TYPE=
+  arguments are given by the renaming command and are used to construct
+  new front matter values if appropriate. If ~denote-rename-confirmations~
+  contains ~rewrite-front-matter~, prompt to confirm the rewriting of
+  the front matter. Otherwise produce a ~y-or-n-p~ prompt to that effect.
 
 #+findex: denote-add-front-matter-prompt
 + Function ~denote-add-front-matter-prompt~ :: Prompt to add a

--- a/denote.el
+++ b/denote.el
@@ -1850,6 +1850,17 @@ this list for new note creation.  The default is `org'.")
   "Return all `denote-file-types' keys."
   (delete-dups (mapcar #'car denote-file-types)))
 
+(defun denote--get-component-key-regexp-function (component)
+  "Return COMPONENT's key regexp function.
+
+COMPONENT can be one of `title', `keywords', `identifier', `date', `signature'."
+  (pcase component
+    ('title #'denote--title-key-regexp)
+    ('keywords #'denote--keywords-key-regexp)
+    ('signature #'denote--signature-key-regexp)
+    ('date #'denote--date-key-regexp)
+    ('identifier #'denote--identifier-key-regexp)))
+
 (defun denote--format-front-matter (title date keywords id signature filetype)
   "Front matter for new notes.
 

--- a/denote.el
+++ b/denote.el
@@ -2251,13 +2251,6 @@ If DATE is nil or an empty string, return nil."
              file))
          (buffer-list))))
 
-(defun denote--id-exists-p (identifier)
-  "Return non-nil if IDENTIFIER already exists."
-  (seq-some
-   (lambda (file)
-     (string= identifier (denote-retrieve-filename-identifier file)))
-   (append (denote-directory-files) (denote--buffer-file-names))))
-
 (defun denote--get-all-used-ids ()
   "Return a hash-table of all used identifiers.
 It checks files in variable `denote-directory' and active buffer files."

--- a/denote.el
+++ b/denote.el
@@ -2957,7 +2957,7 @@ If a buffer is visiting the file, its name is updated."
       (with-current-buffer buffer
         (set-visited-file-name new-name nil t)))))
 
-(defun denote--add-front-matter (file title keywords date id signature file-type)
+(defun denote--add-front-matter (file title keywords signature date id file-type)
   "Prepend front matter to FILE.
 The TITLE, KEYWORDS, DATE, ID, SIGNATURE, and FILE-TYPE are passed from the
 renaming command and are used to construct a new front matter block if
@@ -3132,7 +3132,7 @@ Respect `denote-rename-confirmations', `denote-save-buffers' and
         (if (denote--edit-front-matter-p new-name file-type)
             (denote-rewrite-front-matter new-name title keywords file-type)
           (when (denote-add-front-matter-prompt new-name)
-            (denote--add-front-matter new-name title keywords date id signature file-type))))
+            (denote--add-front-matter new-name title keywords signature date id file-type))))
       (when (and denote--used-ids (not (string-empty-p id)))
         (puthash id t denote--used-ids))
       (denote--handle-save-and-kill-buffer 'rename new-name initial-state)
@@ -3602,7 +3602,7 @@ relevant front matter.
               (id (or (denote-retrieve-filename-identifier file) ""))
               (date (if (string-empty-p id) nil (date-to-time id)))
               (file-type (denote-filetype-heuristics file)))
-    (denote--add-front-matter file title keywords date id "" file-type)))
+    (denote--add-front-matter file title keywords "" date id file-type)))
 
 ;;;###autoload
 (defun denote-change-file-type-and-front-matter (file new-file-type)
@@ -3647,7 +3647,7 @@ Construct the file name in accordance with the user option
       (denote-update-dired-buffers)
       (when (and (denote-file-is-writable-and-supported-p new-name)
                  (denote-add-front-matter-prompt new-name))
-        (denote--add-front-matter new-name title keywords date id signature new-file-type)
+        (denote--add-front-matter new-name title keywords signature date id new-file-type)
         (denote--handle-save-and-kill-buffer 'rename new-name initial-state)))))
 
 ;;;; The Denote faces


### PR DESCRIPTION
This new `denote-rewrite-front-matter` handles all front matter
lines/components. It works on each of them individually. If a line has no
value, it is removed. Removed lines are added again automatically on rename,
in a good position, if they have a non-empty value.

The new `denote-always-include-all-front-matter-lines` controls whether all
lines are present, even if the corresponding value is empty. I made the
default be `t` because that is currently what we are doing for keywords (ie
there is a keywords line even when there is no keywords).

------

This is a big pull request, so you may want to experiment with it before
merging it. You can try removing and reordering lines in a note and in the
front matter template and call something like this:

```
(denote-rewrite-front-matter buffer-file-name "A test" '("journal") "" nil "")
```

You should see the front matter be rebuilt correctly. Try with
`denote-always-include-all-front-matter-lines` set to `nil`.

I also made a comment in the patch about a technicality.

------

After this, it should be easy to add the signature and allow changing the
date/id. `denote-rewrite-front-matter` should now have no issue handling them.