### PR TITLE
Small fixes, `denote-rename-file-using-front-matter` and signature line only when there is a value

### DIFF
--- a/denote.el
+++ b/denote.el
@@ -3256,6 +3256,8 @@ prompt to confirm the rewriting of the front matter."
                            (goto-char (line-beginning-position))
                            (insert new-line)
                            (delete-region (point) (line-end-position))
+                           (goto-char (line-beginning-position 2)))
+                          (t
                            (goto-char (line-beginning-position 2))))))))))))))
 
 ;;;;; The renaming commands and their prompts

--- a/denote.el
+++ b/denote.el
@@ -5027,7 +5027,7 @@ Place the buffer below the current window or wherever the user option
 ;;;;; Add links matching regexp
 
 (defvar denote-link--prepare-links-format "- %s\n"
-  "Format specifiers for `denote-link-add-links'.")
+  "Format specifiers for `denote-add-links'.")
 
 (make-obsolete-variable 'denote-link-add-links-sort nil "3.1.0")
 

--- a/denote.el
+++ b/denote.el
@@ -405,14 +405,22 @@ it again. When in doubt, leave the default file-naming scheme as-is."
           (const :tag "The title of the file" title)
           (const :tag "Keywords of the file" keywords)))
 
-(defcustom denote-always-include-all-front-matter-lines t
-  "Whether to insert front matter lines that have an empty value.
+(defcustom denote-front-matter-components-present-even-if-empty-value '(title keywords date identifier)
+  "The components that are always present in front matter even when empty.
 
-When non-nil (the default), include all front matter lines in new front
-matters, even those with an empty value."
+Components are `title', `keywords', `signature', `date', `identifier'.
+
+Note that even though a component may be listed in this variable, it
+will not be present in the front matter if the corresponding line is not
+in the front matter template."
   :group 'denote
   :package-version '(denote . "3.2.0")
-  :type 'boolean)
+  :type '(list
+          (const :tag "Title" title)
+          (const :tag "Keywords" keywords)
+          (const :tag "Signature" signature)
+          (const :tag "Date" date)
+          (const :tag "Identifier" identifier)))
 
 (defcustom denote-sort-keywords t
   "Whether to sort keywords in new files.
@@ -2999,7 +3007,7 @@ appropriate."
       (goto-char (point-min))
       (insert new-front-matter))
     ;; `denote-rewrite-front-matter' is called to remove lines without a value
-    ;; depending on the value of `denote-always-include-all-front-matter-lines'.
+    ;; depending on the value of `denote-front-matter-components-present-even-if-empty-value'.
     (let ((denote-rename-confirmations nil))
       (denote-rewrite-front-matter file title keywords signature date id file-type))))
 
@@ -3215,7 +3223,8 @@ prompt to confirm the rewriting of the front matter."
                       (denote--component-has-value-p component value))
                  (push component components-to-add))
                 ((and (memq component components-in-file)
-                      (not denote-always-include-all-front-matter-lines) ; The component can still be marked for modification
+                      ;; The component can still be marked for modification.
+                      (not (memq component denote-front-matter-components-present-even-if-empty-value))
                       (not (denote--component-has-value-p component value)))
                  (push component components-to-remove))
                 ((and (memq component components-in-file)

--- a/denote.el
+++ b/denote.el
@@ -3333,9 +3333,12 @@ Respect `denote-rename-confirmations', `denote-save-buffers' and
                           (current-time)))))
          (old-id (or (denote-retrieve-filename-identifier file) ""))
          (id (denote-get-identifier date))
-         (id (if (or (string-empty-p id) (string= old-id id))
-                 id
-               (denote--find-first-unused-id id)))
+         (id (cond ((or (string-empty-p id) (string= old-id id))
+                    id)
+                   ((and (not (string-empty-p old-id)) (denote--file-has-backlinks-p file))
+                    (user-error "The date cannot be modified because the file has backlinks"))
+                   (t
+                    (denote--find-first-unused-id id))))
          (date (if (string-empty-p id) nil (date-to-time id)))
          (new-name (denote-format-file-name directory id keywords title extension signature))
          (max-mini-window-height denote-rename-max-mini-window-height))
@@ -3383,10 +3386,7 @@ renaming commands."
                           signature
                           (format "Rename `%s' with SIGNATURE (empty to remove)" file-in-prompt))))
         ('date
-         (if (and (denote-file-has-identifier-p file)
-                  (denote--file-has-backlinks-p file))
-             (user-error "The date cannot be modified because the file has backlinks")
-           (setq date (denote-valid-date-p (denote-date-prompt)))))))
+         (setq date (denote-valid-date-p (denote-date-prompt))))))
     (list title keywords signature date)))
 
 ;;;###autoload

--- a/denote.el
+++ b/denote.el
@@ -3176,13 +3176,17 @@ This is repeated until all missing components are added."
                 (cdr (seq-drop-while (lambda (x) (not (eq x component))) components-in-template)))
                (first-next-component-in-file
                 (seq-find (lambda (x) (memq x final-components)) next-components-in-template)))
-          ;; Insert before the existing element.
-          (let ((sublist final-components))
-            (while sublist
-              (if (not (eq (car sublist) first-next-component-in-file))
-                  (setq sublist (cdr sublist))
-                (push component sublist)
-                (setq sublist nil)))))))
+          ;; Insert before the existing element.  The intention is to
+          ;; modify final-components, but it does not work when push
+          ;; is called on sublist on the first iteration of the loop.
+          (if (eq (car final-components) first-next-component-in-file)
+              (push component final-components)
+            (let ((sublist final-components))
+              (while sublist
+                (if (not (eq (car sublist) first-next-component-in-file))
+                    (setq sublist (cdr sublist))
+                  (push component sublist)
+                  (setq sublist nil))))))))
     final-components))
 
 (defun denote-rewrite-front-matter (file title keywords signature date identifier file-type)


### PR DESCRIPTION
In this pull request:

- `denote-front-matter-components-present-even-if-empty-value`
  defaulting to `'(title keywords date identifier)`. The signature is
  not included so things should keep working as before for users.

- Fixed smalls issues in `denote--get-file-components-for-rewrite` and
  `denote-rewrite-front-matter`.

- Moved the backlinks check in `denote--rename-file`.

- Refactored `denote-rename-file-using-front-matter`. It was not
  handling all front matter components. Though it was a general issue,
  I think you noticed it when trying to integrate `markdown-obsidian`.
  It should work now. Check its docstring!

------

### markdown-obsidian

I have seen your obsidian branch. I have two small comments:

1- The `denote-*-key-regexp` should not be empty strings for the
missing components, or else it will match. The default value ensures
that there is no match.

2- `#'identity` is not a suitable function for the
`denote-keywords-value-function` and `denote-date-value-function`. The
reason is that the functions should take a list or a date object as
input and return a string for the front matter. `#'identity` does not
do that. I know I gave this example in a previous comment. I realized
it was not valid when I tried to give them default values. It may work
anyway because there is no date or keywords in the front matter
template.

So, a correct definition would be:

```emacs-lisp
(add-to-list
 'denote-file-types
 '(markdown-plain
   :extension ".md"
   :front-matter "# %s\n\n"
   :title-key-regexp "^# "
   :title-value-function identity
   :title-value-reverse-function identity
   :link denote-md-link-format
   :link-in-context-regexp denote-md-link-in-context-regexp))
```