### PR TITLE
Small adjustments for notes without identifier

### DIFF
--- a/README.org
+++ b/README.org
@@ -5949,11 +5949,10 @@ might change them without further notice.
   ([[#h:e7ef08d6-af1b-4ab3-bb00-494a653e6d63][The denote-date-prompt-use-org-read-date option]]). With optional
   =INITIAL-DATE= use it as the initial minibuffer text. With optional
   =PROMPT-TEXT= use it in the minibuffer instead of the default
-  prompt. When ~denote-date-prompt-use-org-read-date~ is non-nil, the
-  value of =INITIAL-DATE= is of the format understood by
-  ~org-read-date~. Otherwise, it is a string that can be processed by
-  ~denote-valid-date-p~. [ The =INITIAL-DATE= and =PROMPT-TEXT= are
-  part of {{{development-version}}}. ]
+  prompt. =INITIAL-DATE= is a string that can be processed by
+  ~denote-valid-date-p~, a value that can be parsed by ~decode-time~
+  or nil. [ The =INITIAL-DATE= and =PROMPT-TEXT= are part of
+  {{{development-version}}}. ]
 
 #+findex: denote-command-prompt
 + Function ~denote-command-prompt~ ::  Prompt for command among

--- a/tests/denote-test.el
+++ b/tests/denote-test.el
@@ -507,15 +507,13 @@ does not involve the time zone."
            (equal (denote--date-convert '(26454 45206 461174 657000) :string)
                   "2024-12-09 10:55:50")
 
-           (equal (denote--date-convert "2024-12-09 10:55:50" :list)
-                  '(26454 45206))
+           (equal (denote--date-convert nil :string)
+                  "")
 
-           (equal (denote--date-convert "2024-12-09 10:55:50" :string)
-                  "2024-12-09 10:55:50")))
+           (equal (denote--date-convert nil :list)
+                  nil)))
   (should-error (denote--date-convert '(26454 45206 461174 657000) :not-valid-type))
-  (should-error (denote--date-convert "2024-12-09 10:55:50" :not-valid-type))
-  (should-error (denote--date-convert "Not right date" :list))
-  (should-error (denote--date-convert "Not right date" :string)))
+  (should-error (denote--date-convert nil :not-valid-type)))
 
 ;;;; denote-journal-extras.el
 


### PR DESCRIPTION
In this pull request:

- I have made adjustments to the recent code about `initial-date`. It
  was not working with `denote-generate-identifier-automatically` and
  notes without identifiers.

- In a recent pull request (#476), I reworked the internal date
  handling functions so that we always only have to work with dates
  that are represented as date objects (or nil for "no date"). I think
  it makes sense to keep this consistent throughout the code. With
  that in mind, `denote--date-convert` can benefit from this
  simplification, as it is an internal function.

- `denote-date-prompt` now accepts an `initial-date` parameter. The
  docstring says that the type of this parameter should depend on the
  value of `denote-date-prompt-use-org-read-date`. This is not really
  true, as the current code will work with strings or lists,
  regardless of `denote-date-prompt-use-org-read-date`. As such, I
  have adapted the docstring to just say that it accepts lists or
  strings. As a public function, it is also okay that it accepts both
  strings and lists, but I made sure to convert it to an internal date
  object right away, to avoid spreading strings down to internal
  functions.