### PR TITLE
In `denote-rename-file', validate a given date before renaming.

### DIFF
--- a/denote.el
+++ b/denote.el
@@ -3664,7 +3664,7 @@ one-by-one, use `denote-dired-rename-files'."
                       signature))
          (date (if (eq date 'keep-current)
                    (denote-valid-date-p (denote-retrieve-filename-identifier file))
-                 date))
+                 (denote-valid-date-p date)))
          (new-name (denote--rename-file file title keywords signature date)))
     (denote-update-dired-buffers)
     new-name))


### PR DESCRIPTION
If the user supplies a string calendar date to `denote-rename-file`, the date is sent through without validation.  If the user has supplied a string calendar date, such as `2025-01-03T08:00`, there will be an error because the process expects a timestamp instead.  This change first validates the date by using `denote-valid-date-p`, which turns the string date into a timestamp, and then proceeds with the file renaming process.  If the provided date is invalid, an error will result.