### PR TITLE
Some fixes

### DIFF
--- a/denote.el
+++ b/denote.el
@@ -5168,7 +5168,9 @@ inserts links with just the identifier."
 
 (defun denote-link--map-over-notes ()
   "Return list of `denote-file-has-denoted-filename-p' from Dired marked items."
-  (seq-filter #'denote-file-has-denoted-filename-p (dired-get-marked-files)))
+  (seq-filter (lambda (file) (and (denote-file-has-denoted-filename-p file)
+                                  (denote-file-has-identifier-p file)))
+              (dired-get-marked-files)))
 
 ;;;###autoload
 (defun denote-link-dired-marked-notes (files buffer &optional id-only)

--- a/denote.el
+++ b/denote.el
@@ -3663,8 +3663,10 @@ one-by-one, use `denote-dired-rename-files'."
                         (or (denote-retrieve-filename-signature file) "")
                       signature))
          (date (if (eq date 'keep-current)
-                   (denote-valid-date-p (denote-retrieve-filename-identifier file))
+                   (denote-retrieve-filename-identifier file)
                  date))
+         ;; Make the data valid
+         (date (denote-valid-date-p date))
          (new-name (denote--rename-file file title keywords signature date)))
     (denote-update-dired-buffers)
     new-name))


### PR DESCRIPTION
In this pull request:

- Fixed issue #513.
- `denote-file-has-denoted-filename-p` does not validate the presence of an identifier. So we also have to check that `denote-file-has-identifier-p` in `denote-link--map-over-notes` because linking requires identifiers.

I wanted to include other small changes. For example, handle the `keep-current` parameter in `denote--rename-file` instead of its current location, but I did not have time. I will do it later.