### PR TITLE
Add identifier comparison sort function in denote-sort-files

### DIFF
--- a/denote-sort.el
+++ b/denote-sort.el
@@ -42,6 +42,14 @@
 (defconst denote-sort-components '(title keywords signature identifier)
   "List of sorting keys applicable for `denote-sort-files' and related.")
 
+(defcustom denote-sort-identifier-comparison-function denote-sort-comparison-fallback-function
+  "Function to sort the SIGNATURE component in file names.
+The function accepts two arguments and must return a non-nil value if
+the first argument is smaller than the second one."
+  :type 'function
+  :package-version '(denote . "3.1.0")
+  :group 'denote-sort)
+
 (defcustom denote-sort-title-comparison-function denote-sort-comparison-fallback-function
   "Function to sort the TITLE component in file names.
 The function accepts two arguments and must return a non-nil value if
@@ -137,6 +145,7 @@ The `%s' performs the comparison."
 
 ;; TODO 2023-12-04: Subject to the above NOTE, we can also sort by
 ;; directory and by file length.
+(denote-sort--define-lessp identifier)
 (denote-sort--define-lessp title)
 (denote-sort--define-lessp keywords)
 (denote-sort--define-lessp signature)
@@ -159,6 +168,7 @@ With optional REVERSE as a non-nil value, reverse the sort order."
   (let* ((files-to-sort (copy-sequence files))
          (sort-fn (pcase component
                     ((pred functionp) component)
+                    ('identifier #'denote-sort-identifier-lessp)
                     ('title #'denote-sort-title-lessp)
                     ('keywords #'denote-sort-keywords-lessp)
                     ('signature #'denote-sort-signature-lessp)))


### PR DESCRIPTION
The function `denote-sort-dired` wasn't working due to the `identifier` missing case in `denote-sort-files`. This is useful when you customize `denote-file-name-components-order`.