### PR TITLE
Use older-compatible `sort` call in `denote-sequence--get-largest`

### DIFF
--- a/denote-sequence.el
+++ b/denote-sequence.el
@@ -192,11 +192,10 @@ means to pad the full length of the sequence."
   "Return largest sequence in SEQUENCES given TYPE.
 TYPE is a symbol among `denote-sequence-types'."
   (car (sort sequences
-             :lessp (lambda (s1 s2)
-                      (string<
-                       (denote-sequence--pad s1 type)
-                       (denote-sequence--pad s2 type)))
-             :reverse t)))
+             (lambda (s1 s2)
+               (string<
+                (denote-sequence--pad s1 type)
+                (denote-sequence--pad s2 type))))))
 
 (defun denote-sequence--get-new-parent (&optional sequences)
   "Return a new to increment largest among sequences.


### PR DESCRIPTION
As pointed out in #516, the `sort` function seems to have a mismatching paradigm depending on the Emacs version the code is run on. However, the `denote-sequence--get-largest` implementation was simply using the `:in-place` key as third argument, while the original implementation of `sort` only accepted two arguments, which is not necessary. The sorting is done in place anyhow. This commit modifies the `denote-sequence--get-largest` function to be compatible with older Emacs versions.