### PR TITLE
New denote-current-title variable

### DIFF
--- a/denote.el
+++ b/denote.el
@@ -2508,6 +2508,13 @@ no matter the value of `denote-save-buffers'."
       (when do-save-buffer (with-current-buffer buffer (save-buffer)))
       (when do-kill-buffer (kill-buffer buffer)))))
 
+(defvar denote-current-title nil
+  "Store the current non-sluggified title.
+
+This may be used by the hooks `denote-after-new-note-hook' and
+`denote-after-rename-file-hook' to access the current non-sluggified
+title, even if there is no front matter present.")
+
 (defvar denote-use-title nil
   "The title to be used in a note creation command.
 See the documentation of `denote' for acceptable values.  This variable
@@ -2677,6 +2684,7 @@ When called from Lisp, all arguments are optional.
                 (denote--creation-prepare-note-data title keywords file-type directory date template signature))
                (note-path (denote--prepare-note title keywords date id directory file-type template signature)))
     (denote--keywords-add-to-history keywords)
+    (setq denote-current-title title)
     (run-hooks 'denote-after-new-note-hook)
     (denote--handle-save-and-kill-buffer 'creation note-path nil)
     note-path))
@@ -3490,6 +3498,7 @@ Respect `denote-rename-confirmations', `denote-save-buffers' and
       (puthash id t denote--used-ids))
     (unless (denote--file-type-org-extra-p)
       (denote--handle-save-and-kill-buffer 'rename new-name initial-state))
+    (setq denote-current-title title)
     (run-hooks 'denote-after-rename-file-hook)
     new-name))
 


### PR DESCRIPTION
I have added `denote-current-title` so that the non-sluggified title
is accessible in `denote-after-new-note-hook` and
`denote-after-rename-file-hook`. This can be useful to those with
a custom front matter (not the default one).

This is not needed for other components because they appear identical
in the file name and the front matter and so they can be retrieved
from the file name.

I will give examples in #532 and #521.