### PR TITLE
Fix false matches in 'denote-sequence-get-all-sequences-with-prefix'

### DIFF
--- a/denote-sequence.el
+++ b/denote-sequence.el
@@ -380,10 +380,18 @@ With optional SEQUENCES operate on those, else use the return value of
 `denote-sequence-get-all-sequences'.
 
 A sequence is a Denote signature that conforms with `denote-sequence-p'."
-  (seq-filter
-   (lambda (string)
-     (string-prefix-p sequence string))
-   (or sequences (denote-sequence-get-all-sequences))))
+  (let* ((prefix (denote-sequence-split sequence))
+         (depth (length prefix)))
+    (seq-filter
+     (lambda (string)
+       (let ((value (denote-sequence-split string))
+             (matched 0))
+         (while (and value
+                     (< matched depth)
+                     (string-equal (pop value) (nth matched prefix)))
+           (setq matched (1+ matched)))
+         (= matched depth)))
+     (or sequences (denote-sequence-get-all-sequences)))))
 
 (defun denote-sequence-get-all-sequences-with-max-depth (depth &optional sequences)
   "Get sequences up to DEPTH (inclusive).


### PR DESCRIPTION
Hi Prot,

This pull request fixes what I believe to be a bug involving the 'denote-sequence' command.

When I have at least 10 top-level sequence notes in my 'denote-directory' and call 'denote-sequence' to create a new child for the parent with sequence "1", the actual parent ends up being that with sequence "10" if there are exactly ten top-level sequence notes, "12" if there are 12, "100" if there are 100, etc.

This all comes down to 'denote-sequence-get-all-sequences-with-prefix' using 'string-match-p' to test for matches. I think it should instead match the components individually.

This is all with the latest main. If there are other branches that I don't know about which address this, apologies!

Thanks!