### PR TITLE
Add tests for false matches addressed by pull request #540 and fix related issues

### DIFF
--- a/denote-sequence.el
+++ b/denote-sequence.el
@@ -621,7 +621,7 @@ returned by `denote-sequence-get-all-files'."
                   (lambda (file)
                     (= (denote-sequence-depth (denote-sequence-file-p file)) (+ depth 1)))
                   (funcall filter-common '> sequence)))
-      (_ (error "The type `%s' is not among the `denote-sequence-types'" type)))))
+      (_ (error "The type `%s' is not among the allowed types" type)))))
 
 (defvar denote-sequence-type-history nil
   "Minibuffer history of `denote-sequence-type-prompt'.")
@@ -917,7 +917,13 @@ For a more specialised case, see `denote-sequence-find-relatives-dired'."
 (defun denote-sequence-find-dired (type)
   "Like `denote-sequence-find' for TYPE but put the matching files in Dired.
 Also see `denote-sequence-dired'."
-  (interactive (list (denote-sequence-type-prompt "Find relatives of TYPE")))
+  (interactive
+   (list (denote-sequence-type-prompt "Find relatives of TYPE"
+                                      '(all-parents
+                                        parent
+                                        siblings
+                                        all-children
+                                        children))))
   (if-let* ((sequence (denote-sequence-file-p buffer-file-name)))
       (if-let* ((default-directory (denote-directory))
                 (relatives (delete buffer-file-name (denote-sequence-get-relative sequence type)))

--- a/denote-sequence.el
+++ b/denote-sequence.el
@@ -928,7 +928,9 @@ Also see `denote-sequence-dired'."
                                         children))))
   (if-let* ((sequence (denote-sequence-file-p buffer-file-name)))
       (if-let* ((default-directory (denote-directory))
-                (relatives (delete buffer-file-name (denote-sequence-get-relative sequence type)))
+                (relatives (delete buffer-file-name
+                                   (ensure-list
+                                    (denote-sequence-get-relative sequence type))))
                 (files-sorted (denote-sequence-sort-files relatives)))
           (dired (cons (format-message "*`%s' type relatives of `%s'" type sequence)
                        (mapcar #'file-relative-name files-sorted)))

--- a/denote-sequence.el
+++ b/denote-sequence.el
@@ -363,7 +363,8 @@ A sequence is a Denote signature that conforms with `denote-sequence-p'.
 
 With optional FILES, operate on them, else use the return value of
 `denote-directory-files'."
-  (let ((prefix (denote-sequence-split sequence)))
+  (when-let* (((not (string-empty-p sequence)))
+              (prefix (denote-sequence-split sequence)))
     (seq-filter
      (lambda (file)
        (when-let* ((file-sequence (denote-sequence-file-p file)))
@@ -396,7 +397,8 @@ With optional SEQUENCES operate on those, else use the return value of
 `denote-sequence-get-all-sequences'.
 
 A sequence is a Denote signature that conforms with `denote-sequence-p'."
-  (let ((prefix (denote-sequence-split sequence)))
+  (when-let* (((not (string-empty-p sequence)))
+              (prefix (denote-sequence-split sequence)))
     (seq-filter
      (lambda (string)
        (denote-sequence--sequence-prefix-p prefix string))

--- a/tests/denote-test.el
+++ b/tests/denote-test.el
@@ -616,9 +616,15 @@ function `denote-sequence-get-relative'."
              "20241230T075023==1=2--test__testing.txt"
              "20241230T075023==1=2=1--test__testing.txt"
              "20241230T075023==1=2=1=1--test__testing.txt"
-             "20241230T075023==2--test__testing.txt")))
+             "20241230T075023==2--test__testing.txt"
+             "20241230T075023==10--test__testing.txt"
+             "20241230T075023==10=1--test__testing.txt"
+             "20241230T075023==10=1=1--test__testing.txt"
+             "20241230T075023==10=2--test__testing.txt"
+             "20241230T075023==10=10--test__testing.txt"
+             "20241230T075023==10=10=1--test__testing.txt")))
          (sequences (denote-sequence-get-all-sequences files)))
-    (should (string= (denote-sequence-get-new 'parent) "3"))
+    (should (string= (denote-sequence-get-new 'parent) "11"))
 
     (should (and (string= (denote-sequence-get-new 'child "1" sequences) "1=3")
                  (string= (denote-sequence-get-new 'child "1=1" sequences) "1=1=3")
@@ -626,96 +632,131 @@ function `denote-sequence-get-relative'."
                  (string= (denote-sequence-get-new 'child "1=2" sequences) "1=2=2")
                  (string= (denote-sequence-get-new 'child "1=2=1" sequences) "1=2=1=2")
                  (string= (denote-sequence-get-new 'child "2" sequences) "2=1")))
-    (should-error (denote-sequence-get-new 'child "3" sequences))
+    (should-error (denote-sequence-get-new 'child "11" sequences))
 
-    (should (and (string= (denote-sequence-get-new 'sibling "1" sequences) "3")
+    (should (and (string= (denote-sequence-get-new 'sibling "1" sequences) "11")
                  (string= (denote-sequence-get-new 'sibling "1=1" sequences) "1=3")
                  (string= (denote-sequence-get-new 'sibling "1=1=1" sequences) "1=1=3")
                  (string= (denote-sequence-get-new 'sibling "1=1=2" sequences) "1=1=3")
                  (string= (denote-sequence-get-new 'sibling "1=2" sequences) "1=3")
                  (string= (denote-sequence-get-new 'sibling "1=2=1" sequences) "1=2=2")
-                 (string= (denote-sequence-get-new 'sibling "2" sequences) "3")))
-    (should-error (denote-sequence-get-new 'sibling "4" sequences))
+                 (string= (denote-sequence-get-new 'sibling "2" sequences) "11")))
+    (should-error (denote-sequence-get-new 'sibling "12" sequences))
 
     (should (string= (denote-sequence-get-relative "1=2=1=1" 'parent files)
                      (expand-file-name "20241230T075023==1=2=1--test__testing.txt" denote-directory)))
+    (should (string= (denote-sequence-get-relative "10=1=1" 'parent files)
+                     (expand-file-name "20241230T075023==10=1--test__testing.txt" denote-directory)))
+    (should (string= (denote-sequence-get-relative "10=10=1" 'parent files)
+                     (expand-file-name "20241230T075023==10=10--test__testing.txt" denote-directory)))
     (should (equal (denote-sequence-get-relative "1=2=1=1" 'all-parents files)
                    (list
                     (expand-file-name "20241230T075023==1--test__testing.txt" denote-directory)
                     (expand-file-name "20241230T075023==1=2--test__testing.txt" denote-directory)
                     (expand-file-name "20241230T075023==1=2=1--test__testing.txt" denote-directory))))
+    (should (equal (denote-sequence-get-relative "10=1=1" 'all-parents files)
+                   (list
+                    (expand-file-name "20241230T075023==10--test__testing.txt" denote-directory)
+                    (expand-file-name "20241230T075023==10=1--test__testing.txt" denote-directory))))
+    (should (equal (denote-sequence-get-relative "10=10=1" 'all-parents files)
+                   (list
+                    (expand-file-name "20241230T075023==10--test__testing.txt" denote-directory)
+                    (expand-file-name "20241230T075023==10=10--test__testing.txt" denote-directory))))
     (should (equal (denote-sequence-get-relative "1=1" 'siblings files)
                    (list
                     (expand-file-name "20241230T075023==1=1--test__testing.txt" denote-directory)
                     (expand-file-name "20241230T075023==1=2--test__testing.txt" denote-directory))))
+    (should (equal (denote-sequence-get-relative "10=1" 'siblings files)
+                   (list
+                    (expand-file-name "20241230T075023==10=1--test__testing.txt" denote-directory)
+                    (expand-file-name "20241230T075023==10=2--test__testing.txt" denote-directory)
+                    (expand-file-name "20241230T075023==10=10--test__testing.txt" denote-directory))))
     (should (equal (denote-sequence-get-relative "1" 'children files)
                    (list
                     (expand-file-name "20241230T075023==1=1--test__testing.txt" denote-directory)
                     (expand-file-name "20241230T075023==1=2--test__testing.txt" denote-directory))))
+    (should (equal (denote-sequence-get-relative "10" 'children files)
+                   (list
+                    (expand-file-name "20241230T075023==10=1--test__testing.txt" denote-directory)
+                    (expand-file-name "20241230T075023==10=2--test__testing.txt" denote-directory)
+                    (expand-file-name "20241230T075023==10=10--test__testing.txt" denote-directory))))
     (should (equal (denote-sequence-get-relative "1=1" 'all-children files)
                    (list
                     (expand-file-name "20241230T075023==1=1=1--test__testing.txt" denote-directory)
                     (expand-file-name "20241230T075023==1=1=2--test__testing.txt" denote-directory)))))
 
-    (let* ((denote-sequence-scheme 'alphanumeric)
-           (denote-directory (expand-file-name "denote-test" temporary-file-directory))
-           (files
-            (mapcar
-             (lambda (file)
-               (let ((path (expand-file-name file (denote-directory))))
-                 (if (file-exists-p path)
-                     path
-                   (with-current-buffer (find-file-noselect path)
-                     (save-buffer)
-                     (kill-buffer (current-buffer)))
-                   path)))
-             '("20241230T075023==1--test__testing.txt"
-               "20241230T075023==1a--test__testing.txt"
-               "20241230T075023==1a1--test__testing.txt"
-               "20241230T075023==1a2--test__testing.txt"
-               "20241230T075023==1b--test__testing.txt"
-               "20241230T075023==1b1--test__testing.txt"
-               "20241230T075023==1b1a--test__testing.txt"
-               "20241230T075023==2--test__testing.txt")))
-           (sequences (denote-sequence-get-all-sequences files)))
-      (should (string= (denote-sequence-get-new 'parent) "3"))
+  (let* ((denote-sequence-scheme 'alphanumeric)
+         (denote-directory (expand-file-name "denote-test" temporary-file-directory))
+         (files
+          (mapcar
+           (lambda (file)
+             (let ((path (expand-file-name file (denote-directory))))
+               (if (file-exists-p path)
+                   path
+                 (with-current-buffer (find-file-noselect path)
+                   (save-buffer)
+                   (kill-buffer (current-buffer)))
+                 path)))
+           '("20241230T075023==1--test__testing.txt"
+             "20241230T075023==1a--test__testing.txt"
+             "20241230T075023==1a1--test__testing.txt"
+             "20241230T075023==1a2--test__testing.txt"
+             "20241230T075023==1b--test__testing.txt"
+             "20241230T075023==1b1--test__testing.txt"
+             "20241230T075023==1b1a--test__testing.txt"
+             "20241230T075023==2--test__testing.txt"
+             "20241230T075023==10--test__testing.txt"
+             "20241230T075023==10a--test__testing.txt"
+             "20241230T075023==10b--test__testing.txt")))
+         (sequences (denote-sequence-get-all-sequences files)))
+    (should (string= (denote-sequence-get-new 'parent) "11"))
 
-      (should (and (string= (denote-sequence-get-new 'child "1" sequences) "1c")
-                   (string= (denote-sequence-get-new 'child "1a" sequences) "1a3")
-                   (string= (denote-sequence-get-new 'child "1a2" sequences) "1a2a")
-                   (string= (denote-sequence-get-new 'child "1b" sequences) "1b2")
-                   (string= (denote-sequence-get-new 'child "1b1" sequences) "1b1b")
-                   (string= (denote-sequence-get-new 'child "2" sequences) "2a")))
-      (should-error (denote-sequence-get-new 'child "3" sequences))
+    (should (and (string= (denote-sequence-get-new 'child "1" sequences) "1c")
+                 (string= (denote-sequence-get-new 'child "1a" sequences) "1a3")
+                 (string= (denote-sequence-get-new 'child "1a2" sequences) "1a2a")
+                 (string= (denote-sequence-get-new 'child "1b" sequences) "1b2")
+                 (string= (denote-sequence-get-new 'child "1b1" sequences) "1b1b")
+                 (string= (denote-sequence-get-new 'child "2" sequences) "2a")))
+    (should-error (denote-sequence-get-new 'child "11" sequences))
 
-      (should (and (string= (denote-sequence-get-new 'sibling "1" sequences) "3")
-                   (string= (denote-sequence-get-new 'sibling "1a" sequences) "1c")
-                   (string= (denote-sequence-get-new 'sibling "1a1" sequences) "1a3")
-                   (string= (denote-sequence-get-new 'sibling "1a2" sequences) "1a3")
-                   (string= (denote-sequence-get-new 'sibling "1b" sequences) "1c")
-                   (string= (denote-sequence-get-new 'sibling "1b1" sequences) "1b2")
-                   (string= (denote-sequence-get-new 'sibling "2" sequences) "3")))
-      (should-error (denote-sequence-get-new 'sibling "4" sequences))
+    (should (and (string= (denote-sequence-get-new 'sibling "1" sequences) "11")
+                 (string= (denote-sequence-get-new 'sibling "1a" sequences) "1c")
+                 (string= (denote-sequence-get-new 'sibling "1a1" sequences) "1a3")
+                 (string= (denote-sequence-get-new 'sibling "1a2" sequences) "1a3")
+                 (string= (denote-sequence-get-new 'sibling "1b" sequences) "1c")
+                 (string= (denote-sequence-get-new 'sibling "1b1" sequences) "1b2")
+                 (string= (denote-sequence-get-new 'sibling "2" sequences) "11")))
+    (should-error (denote-sequence-get-new 'sibling "12" sequences))
 
-      (should (string= (denote-sequence-get-relative "1b1a" 'parent files)
-                       (expand-file-name "20241230T075023==1b1--test__testing.txt" denote-directory)))
-      (should (equal (denote-sequence-get-relative "1b1a" 'all-parents files)
-                     (list
-                      (expand-file-name "20241230T075023==1--test__testing.txt" denote-directory)
-                      (expand-file-name "20241230T075023==1b--test__testing.txt" denote-directory)
-                      (expand-file-name "20241230T075023==1b1--test__testing.txt" denote-directory))))
-      (should (equal (denote-sequence-get-relative "1a" 'siblings files)
-                     (list
-                      (expand-file-name "20241230T075023==1a--test__testing.txt" denote-directory)
-                      (expand-file-name "20241230T075023==1b--test__testing.txt" denote-directory))))
-      (should (equal (denote-sequence-get-relative "1" 'children files)
-                     (list
-                      (expand-file-name "20241230T075023==1a--test__testing.txt" denote-directory)
-                      (expand-file-name "20241230T075023==1b--test__testing.txt" denote-directory))))
-      (should (equal (denote-sequence-get-relative "1a" 'all-children files)
-                     (list
-                      (expand-file-name "20241230T075023==1a1--test__testing.txt" denote-directory)
-                      (expand-file-name "20241230T075023==1a2--test__testing.txt" denote-directory))))))
+    (should (string= (denote-sequence-get-relative "1b1a" 'parent files)
+                     (expand-file-name "20241230T075023==1b1--test__testing.txt" denote-directory)))
+    (should (string= (denote-sequence-get-relative "10a" 'parent files)
+                     (expand-file-name "20241230T075023==10--test__testing.txt" denote-directory)))
+    (should (equal (denote-sequence-get-relative "1b1a" 'all-parents files)
+                   (list
+                    (expand-file-name "20241230T075023==1--test__testing.txt" denote-directory)
+                    (expand-file-name "20241230T075023==1b--test__testing.txt" denote-directory)
+                    (expand-file-name "20241230T075023==1b1--test__testing.txt" denote-directory))))
+    (should (equal (denote-sequence-get-relative "1a" 'siblings files)
+                   (list
+                    (expand-file-name "20241230T075023==1a--test__testing.txt" denote-directory)
+                    (expand-file-name "20241230T075023==1b--test__testing.txt" denote-directory))))
+    (should (equal (denote-sequence-get-relative "10a" 'siblings files)
+                   (list
+                    (expand-file-name "20241230T075023==10a--test__testing.txt" denote-directory)
+                    (expand-file-name "20241230T075023==10b--test__testing.txt" denote-directory))))
+    (should (equal (denote-sequence-get-relative "1" 'children files)
+                   (list
+                    (expand-file-name "20241230T075023==1a--test__testing.txt" denote-directory)
+                    (expand-file-name "20241230T075023==1b--test__testing.txt" denote-directory))))
+    (should (equal (denote-sequence-get-relative "10" 'children files)
+                   (list
+                    (expand-file-name "20241230T075023==10a--test__testing.txt" denote-directory)
+                    (expand-file-name "20241230T075023==10b--test__testing.txt" denote-directory))))
+    (should (equal (denote-sequence-get-relative "1a" 'all-children files)
+                   (list
+                    (expand-file-name "20241230T075023==1a1--test__testing.txt" denote-directory)
+                    (expand-file-name "20241230T075023==1a2--test__testing.txt" denote-directory))))))
 
 (ert-deftest dt-denote-sequence-split ()
   "Test that `denote-sequence-split' splits a sequence correctly."


### PR DESCRIPTION
This adds tests as mentioned in pull request #540. It also fixes similar false matches in 'denote-sequence-get-all-files-with-prefix'.

The latter function is apparently mainly used by 'denote-sequence-find-dired', and in the process of trying that command out, I found a number of bugs involvings its use of ''denote-sequence-get-relative' --- which I fix here as well.