### PR TITLE
Revert commits about renaming org-capture buffers

### DIFF
--- a/denote.el
+++ b/denote.el
@@ -2383,23 +2383,21 @@ Also see `denote-extract-keywords-from-path' (alias
 (defun denote--file-with-temp-buffer-subr (file)
   "Return path to FILE or its buffer together with the appropriate function.
 Subroutine of `denote--file-with-temp-buffer'."
-  (if (denote--file-type-org-extra-p)
-      (cons #'insert-buffer (current-buffer))
-    (let* ((buffer (get-file-buffer file))
-           (file-exists (file-exists-p file))
-           (buffer-modified (buffer-modified-p buffer)))
-      (cond
-       ((or (and file-exists
-                 buffer
-                 (not buffer-modified)
-                 (not (eq buffer-modified 'autosaved)))
-            (and file-exists (not buffer)))
-        (cons #'insert-file-contents file))
-       (buffer
-        (cons #'insert-buffer buffer))
-       ;; (t
-       ;;  (error "Cannot find anything about file `%s'" file))
-       ))))
+  (let* ((buffer (get-file-buffer file))
+         (file-exists (file-exists-p file))
+         (buffer-modified (buffer-modified-p buffer)))
+    (cond
+     ((or (and file-exists
+               buffer
+               (not buffer-modified)
+               (not (eq buffer-modified 'autosaved)))
+          (and file-exists (not buffer)))
+      (cons #'insert-file-contents file))
+     (buffer
+      (cons #'insert-buffer buffer))
+     ;; (t
+     ;;  (error "Cannot find anything about file `%s'" file))
+     )))
 
 (defmacro denote--file-with-temp-buffer (file &rest body)
   "If FILE exists, insert its contents in a temp buffer and call BODY."
@@ -3462,8 +3460,6 @@ Also revert the current Dired buffer even if it is not inside the
 variable `denote-directory'."
   (mapc #'denote--revert-dired (buffer-list)))
 
-(defvar denote-last-path nil "Store last path.")
-
 (defun denote-rename-file-and-buffer (old-name new-name)
   "Rename file named OLD-NAME to NEW-NAME, updating buffer name.
 
@@ -3473,24 +3469,22 @@ not exist yet.
 
 If a buffer is visiting the file, its name is updated."
   (unless (string= (expand-file-name old-name) (expand-file-name new-name))
-    (if (denote--file-type-org-extra-p)
-        (setq denote-last-path new-name)
-      (when (and (file-regular-p old-name)
-                 (file-writable-p new-name))
-        (cond
-         ((derived-mode-p 'dired-mode)
-          (dired-rename-file old-name new-name nil))
-         ;; NOTE 2024-02-25: The `vc-rename-file' requires the file to be
-         ;; saved, but our convention is to not save the buffer after
-         ;; changing front matter unless we absolutely have to (allows
-         ;; users to do `diff-buffer-with-file', for example).
-         ((and denote-save-buffers (not (buffer-modified-p)) (vc-backend old-name))
-          (vc-rename-file old-name new-name))
-         (t
-          (rename-file old-name new-name nil))))
-      (when-let* ((buffer (find-buffer-visiting old-name)))
-        (with-current-buffer buffer
-          (set-visited-file-name new-name nil t))))))
+    (when (and (file-regular-p old-name)
+               (file-writable-p new-name))
+      (cond
+       ((derived-mode-p 'dired-mode)
+        (dired-rename-file old-name new-name nil))
+       ;; NOTE 2024-02-25: The `vc-rename-file' requires the file to be
+       ;; saved, but our convention is to not save the buffer after
+       ;; changing front matter unless we absolutely have to (allows
+       ;; users to do `diff-buffer-with-file', for example).
+       ((and denote-save-buffers (not (buffer-modified-p)) (vc-backend old-name))
+        (vc-rename-file old-name new-name))
+       (t
+        (rename-file old-name new-name nil))))
+    (when-let* ((buffer (find-buffer-visiting old-name)))
+      (with-current-buffer buffer
+        (set-visited-file-name new-name nil t)))))
 
 (define-obsolete-function-alias
   'denote--add-front-matter
@@ -3503,9 +3497,7 @@ The TITLE, KEYWORDS, DATE, ID, SIGNATURE, and FILE-TYPE are passed from
 the renaming command and are used to construct a new front matter block
 if appropriate."
   (when-let* ((new-front-matter (denote--format-front-matter title date keywords id signature file-type)))
-    (with-current-buffer (if (denote--file-type-org-extra-p)
-                             denote-last-path-after-rename
-                           (find-file-noselect file))
+    (denote--file-with-temp-buffer file
       (goto-char (point-min))
       (insert new-front-matter))))
 
@@ -3555,22 +3547,22 @@ identifier.  It also returns nil given a nil date or nil keywords."
     ('date (not (null value)))
     ('identifier (not (string-empty-p value)))))
 
-(defun denote--get-old-and-new-front-matter-lines (file-content new-front-matter file-type)
+(defun denote--get-old-and-new-front-matter-lines (file new-front-matter file-type)
   "Return an alist of the old and new front-matter lines for each component.
 
-The FILE-CONTENT contains the old front matter lines.
+The FILE contains the old front matter lines.
 
 NEW-FRONT-MATTER is a the front matter with the new values, with the
 format given by FILE-TYPE."
-  `((title . ((old . ,(denote--retrieve-front-matter-title-line-from-content file-content file-type))
+  `((title . ((old . ,(denote-retrieve-front-matter-title-line file file-type))
               (new . ,(denote--retrieve-front-matter-title-line-from-content new-front-matter file-type))))
-    (keywords . ((old . ,(denote--retrieve-front-matter-keywords-line-from-content file-content file-type))
+    (keywords . ((old . ,(denote-retrieve-front-matter-keywords-line file file-type))
                  (new . ,(denote--retrieve-front-matter-keywords-line-from-content new-front-matter file-type))))
-    (signature . ((old . ,(denote--retrieve-front-matter-signature-line-from-content file-content file-type))
+    (signature . ((old . ,(denote-retrieve-front-matter-signature-line file file-type))
                   (new . ,(denote--retrieve-front-matter-signature-line-from-content new-front-matter file-type))))
-    (date . ((old . ,(denote--retrieve-front-matter-date-line-from-content file-content file-type))
+    (date . ((old . ,(denote-retrieve-front-matter-date-line file file-type))
              (new . ,(denote--retrieve-front-matter-date-line-from-content new-front-matter file-type))))
-    (identifier . ((old . ,(denote--retrieve-front-matter-identifier-line-from-content file-content file-type))
+    (identifier . ((old . ,(denote-retrieve-front-matter-identifier-line file file-type))
                    (new . ,(denote--retrieve-front-matter-identifier-line-from-content new-front-matter file-type))))))
 
 (defun denote--get-front-matter-components-order (content file-type)
@@ -3607,7 +3599,7 @@ entire file content."
 This is checked against its front matter definition.  If the front matter
 definition has no lines, this function returns non-nil."
   (let* ((front-matter (denote--front-matter file-type))
-         (file-content (denote--file-with-temp-buffer file (buffer-string)))
+         (file-content (with-current-buffer (find-file-noselect file) (buffer-string)))
          (components-in-template (denote--get-front-matter-components-order front-matter file-type))
          (components-in-file (denote--get-front-matter-components-order file-content file-type)))
     (or (null components-in-template)
@@ -3704,14 +3696,14 @@ matter values if appropriate.
 If `denote-rename-confirmations' contains `rewrite-front-matter',
 prompt to confirm the rewriting of the front matter."
   (let* ((front-matter (denote--front-matter file-type))
-         (file-content (denote--file-with-temp-buffer file (buffer-string)))
+         (file-content (with-current-buffer (find-file-noselect file) (buffer-string)))
          (components-in-template (denote--get-front-matter-components-order front-matter file-type))
          (components-in-file (denote--get-front-matter-components-order file-content file-type))
          (components-to-add '())
          (components-to-remove '())
          (components-to-modify '())
          (new-front-matter (denote--format-front-matter title date keywords identifier signature file-type))
-         (old-and-new-front-matter-lines (denote--get-old-and-new-front-matter-lines file-content new-front-matter file-type)))
+         (old-and-new-front-matter-lines (denote--get-old-and-new-front-matter-lines file new-front-matter file-type)))
     ;; Build the lists of components to add, remove, modify.
     (dolist (component '(title keywords signature identifier date))
       ;; Ignore the component if it is not in the template.  It is not added, removed or modified.
@@ -3734,9 +3726,7 @@ prompt to confirm the rewriting of the front matter."
                (or components-to-add components-to-remove components-to-modify))
       (when-let* ((final-components (denote--get-final-components-for-rewrite
                                      components-in-file components-in-template components-to-add)))
-        (with-current-buffer (if (denote--file-type-org-extra-p)
-                                 (current-buffer)
-                               (find-file-noselect file))
+        (with-current-buffer (find-file-noselect file)
           (when (or (not (memq 'rewrite-front-matter denote-rename-confirmations))
                     (y-or-n-p (denote--get-front-matter-rewrite-prompt
                                final-components
@@ -3871,8 +3861,7 @@ Respect `denote-rename-confirmations', `denote-save-buffers' and
           (denote-prepend-front-matter new-name title keywords signature date id file-type))))
     (when (and denote--used-ids (not (string-empty-p id)))
       (puthash id t denote--used-ids))
-    (unless (denote--file-type-org-extra-p)
-      (denote--handle-save-and-kill-buffer 'rename new-name initial-state))
+    (denote--handle-save-and-kill-buffer 'rename new-name initial-state)
     (setq denote-current-data
           (list
            (cons 'title title)
@@ -4036,9 +4025,7 @@ file-naming scheme.
 For a version of this command that works with multiple files
 one-by-one, use `denote-dired-rename-files'."
   (interactive
-   (let* ((file (if (denote--file-type-org-extra-p)
-                    denote-last-path
-                  (denote--rename-dired-file-or-current-file-or-prompt))))
+   (let* ((file (denote--rename-dired-file-or-current-file-or-prompt)))
      (append (list file) (denote--rename-get-file-info-from-prompts-or-existing file))))
   (let* ((file-type (denote-filetype-heuristics file))
          (title (if (eq title 'keep-current)
@@ -4272,9 +4259,7 @@ prompt for this if `denote-rename-confirmations' contains
 
 Construct the file name in accordance with the user option
 `denote-file-name-components-order'."
-  (interactive (list (if (denote--file-type-org-extra-p)
-                         denote-last-path
-                       (or (dired-get-filename nil t) buffer-file-name))))
+  (interactive (list (or (dired-get-filename nil t) buffer-file-name)))
   (unless (denote-file-is-writable-and-supported-p file)
     (user-error "The file is not writable or does not have a supported file extension"))
   (let ((file-type (denote-filetype-heuristics file)))
@@ -5853,6 +5838,8 @@ the standard front matter we define."
   "Return non-nil if `denote-org-capture-specifiers' uses link specifiers."
   (when (stringp denote-org-capture-specifiers)
     (string-match-p "%^?[aAlL]" denote-org-capture-specifiers)))
+
+(defvar denote-last-path nil "Store last path.")
 
 ;;;###autoload
 (defun denote-org-capture ()


### PR DESCRIPTION
This is following the discussion [here](https://github.com/protesilaos/denote/issues/550#issuecomment-2693343371) where we decided to take a step back about the renaming of notes inside an org-capture buffer because it causes issues.

I reverted the relevant commits.

Issue #550 may still not be resolved, but I cannot reproduce it.