### PR TITLE
Respect encryption-file-extensions in get-path-by-id

### DIFF
--- a/denote.el
+++ b/denote.el
@@ -1395,7 +1395,7 @@ something like .org even if the actual file extension is
         (car files)
       (seq-find
        (lambda (file)
-         (let ((file-extension (denote-get-file-extension file)))
+         (let ((file-extension (denote-get-file-extension-sans-encryption file)))
            (and (denote-file-has-supported-extension-p file)
                 (or (string= (denote--file-extension denote-file-type)
                              file-extension)


### PR DESCRIPTION
This fixes a problem with opening links to encrypted `org` files.
For example, if the target file has been exported with the same name, the following error occurs:

```
denote-link-ol-follow: Wrong type argument: stringp, nil
```