### PR TITLE
Bypass `org-store-link` called by `org-capture`

### DIFF
--- a/denote.el
+++ b/denote.el
@@ -5747,6 +5747,7 @@ Also see the user option `denote-org-store-link-to-heading'."
                                 (derived-mode-p 'org-mode)
                                 (denote--org-capture-link-specifiers-p)))
             (heading (denote-link-ol-get-heading)))
+       (unless (consp orig-buf)
         (org-link-store-props
          :type "denote"
          :description (if (and heading-links heading)
@@ -5763,7 +5764,7 @@ Also see the user option `denote-org-store-link-to-heading'."
                  (format "denote:%s::#%s" file-id (denote-link-ol-get-id)))
                 (t
                  (concat "denote:" file-id))))
-        org-store-link-plist))))
+        org-store-link-plist)))))
 
 ;;;###autoload
 (defun denote-link-ol-export (link description format)


### PR DESCRIPTION
As the issues (https://github.com/protesilaos/denote/issues/548 and https://github.com/protesilaos/denote/issues/267) mentioned, when we set `denote-org-store-link-to-heading` to non-nil and run `org-capture` in a denote file, the heading where cursor stays will be add a property `CUSTOM_ID`.

According to the `org-capture` function(https://github.com/emacs-mirror/emacs/blob/2d278a0f2e945eef30752550f900c1c88367fb6b/lisp/org/org-capture.el#L678-L684):

```lisp
(let* ((orig-buf (current-buffer))
	   (annotation (if (and (boundp 'org-capture-link-is-already-stored)
				org-capture-link-is-already-stored)
			   (plist-get org-store-link-plist :annotation)
			 (ignore-errors (org-store-link nil))))
	   (entry (or org-capture-entry (org-capture-select-template keys)))
	   initial)
```

 It calls `org-store-link` to get the annotation, and `org-store-link` will call `denote-link-ol-store` in denote files.

So we can add a conditional `unless` function to detect the local variable `orig-buf` set by `org-capture`. 

If it exists, `denote-link-ol-store` should skip creating links (especially `CUSTOM_ID`).