### PR TITLE
Small fixes

### DIFF
--- a/README.org
+++ b/README.org
@@ -5108,7 +5108,7 @@ The following sections cover the specifics.
 #+findex: denote-use-keywords
 + Function ~denote-use-keywords~ :: The keywords to be used in a note
   creation command. See the documentation of ~denote~ for acceptable
-  values. This variable is ignored if nil. Only ever ~let~ bind this,
+  values. This variable is ignored if ~default~. Only ever ~let~ bind this,
   otherwise the title will always be the same and the title prompt
   will be skipped.
 

--- a/denote.el
+++ b/denote.el
@@ -2812,10 +2812,10 @@ is ignored if nil.
 Only ever `let' bind this, otherwise the title will always be the same
 and the title prompt will be skipped.")
 
-(defvar denote-use-keywords nil
+(defvar denote-use-keywords 'default
   "The keywords to be used in a note creation command.
 See the documentation of `denote' for acceptable values.  This variable
-is ignored if nil.
+is ignored if `default'.
 
 Only ever `let' bind this, otherwise the keywords will always be the same
 and the keywords prompt will be skipped.")
@@ -2881,7 +2881,7 @@ instead."
                                  (buffer-substring-no-properties
                                   (region-beginning)
                                   (region-end)))))))
-        ('keywords (unless denote-use-keywords
+        ('keywords (when (eq denote-use-keywords 'default)
                      (setq keywords (denote-keywords-prompt))))
         ('file-type (unless denote-use-file-type
                       (setq file-type (denote-file-type-prompt))))
@@ -2905,7 +2905,7 @@ If a `denote-use-*' variable is set for a data, its value is used
 instead of that of the parameter."
   (let* (;; Handle the `denote-use-*' variables
          (title (or denote-use-title title))
-         (keywords (or denote-use-keywords keywords))
+         (keywords (if (eq denote-use-keywords 'default) keywords denote-use-keywords))
          (file-type (or denote-use-file-type file-type))
          (directory (or denote-use-directory directory))
          (date (or denote-use-date date))

--- a/denote.el
+++ b/denote.el
@@ -3083,9 +3083,7 @@ a value that can be parsed by `decode-time' or nil."
             (setq time (time-add time (string-to-number cur-time-seconds))))
           (format-time-string "%Y-%m-%d %H:%M:%S" time))
       (read-string
-       (or
-        "DATE and TIME for note (e.g. 2022-06-16 14:30): "
-        prompt-text)
+       (or prompt-text "DATE and TIME for note (e.g. 2022-06-16 14:30): ")
        (denote--date-convert initial-date :string)
        'denote-date-history))))
 


### PR DESCRIPTION
- I changed the order of the `or` subexpressions in `denote-date-prompt`. It was probably unintended.

- I changed the default value of `denote-use-keywords` to the `default` symbol, because `nil` (ie the empty list) is a valid value for keywords.