### PR TITLE
Fix Windows compatibility of `denote-link-ol-follow`

### DIFF
--- a/denote.el
+++ b/denote.el
@@ -6082,7 +6082,7 @@ query of file contents or file names (see the commands
 
 Uses the function `denote-directory' to establish the path to the file."
   (if-let* ((match (denote-link--ol-resolve-link-to-target link))
-            (_ (file-exists-p (string-trim-right match ":.*"))))
+            (_ (file-exists-p (string-trim-right match ":[^/]+.*"))))
       (org-link-open-as-file match nil)
     (denote--act-on-query-link match)))
 


### PR DESCRIPTION
On Windows, given the `link` as an identifer `"20250312T161853"` , the result of `(denote-link--ol-resolve-link-to-target 
 link)` is a Windows path `"c:/path/to/the/file.extension"`

However, the result of `(file-exists-p (string-trim-right match ":.*"))` is `nil`, because `(string-trim-right "c:/path/to/the/file.extension" ":.*")` returns `"c"` ,which is the driver letter on Windows.

We can fix it by this: `(string-trim-right "c:/path/to/the/file.extension" ":[^/]+.*")`

https://github.com/protesilaos/denote/issues/577