### PR TITLE
Remove include-date parameter from linking functions

### DIFF
--- a/denote.el
+++ b/denote.el
@@ -4742,31 +4742,24 @@ The format of such links is `denote-md-link-format'.")
   "Regexp to match an identifier-only link in its context.
 The format of such links is `denote-id-only-link-format'."  )
 
-(defun denote-format-link (file description file-type id-only &optional include-date)
+(defun denote-format-link (file description file-type id-only)
   "Prepare link to FILE using DESCRIPTION.
 
 FILE-TYPE and ID-ONLY are used to get the format of the link.
-See the `:link' property of `denote-file-types'.
-
-With optional INCLUDE-DATE, convert the identifier using
-`denote--id-to-date' and append it to DESCRIPTION."
-  (let* ((identifier (denote-retrieve-filename-identifier file))
-         (desc (if include-date
-                   (format "%s (%s)" description (denote--id-to-date identifier))
-                 description)))
-    (format
-     (cond
-      ((or id-only (null description) (string-empty-p description))
-       denote-id-only-link-format)
-      ;; NOTE 2024-05-20: If there is no file type, we want to use the
-      ;; Org format because it is still a usable link with the help of
-      ;; the command `org-open-at-point-global'.
-      ((null file-type)
-       (denote--link-format 'org))
-      (t
-       (denote--link-format file-type)))
-     identifier
-     desc)))
+See the `:link' property of `denote-file-types'."
+  (format
+   (cond
+    ((or id-only (null description) (string-empty-p description))
+     denote-id-only-link-format)
+    ;; NOTE 2024-05-20: If there is no file type, we want to use the
+    ;; Org format because it is still a usable link with the help of
+    ;; the command `org-open-at-point-global'.
+    ((null file-type)
+     (denote--link-format 'org))
+    (t
+     (denote--link-format file-type)))
+   (denote-retrieve-filename-identifier file)
+   desc))
 
 (defun denote-link-description-with-signature-and-title (file)
   "Return link description for FILE.
@@ -5898,25 +5891,23 @@ major mode is not `org-mode' (or derived therefrom).  Consider using
 
 (make-obsolete-variable 'denote-link-add-links-sort nil "3.1.0")
 
-(defun denote-link--prepare-links (files current-file-type id-only &optional no-sort include-date)
+(defun denote-link--prepare-links (files current-file-type id-only &optional no-sort)
   "Prepare links to FILES from CURRENT-FILE-TYPE.
 When ID-ONLY is non-nil, use a generic link format.
 
 With optional NO-SORT do not try to sort the inserted lines.
-Otherwise sort lines while accounting for `denote-link-add-links-sort'.
-
-Optional INCLUDE-DATE has the same meaning as in `denote-format-link'."
+Otherwise sort lines while accounting for `denote-link-add-links-sort'."
   (let ((links))
     (dolist (file files)
       (let* ((description (denote-get-link-description file))
-             (link (denote-format-link file description current-file-type id-only include-date))
+             (link (denote-format-link file description current-file-type id-only))
              (link-as-list-item (format denote-link--prepare-links-format link)))
         (push link-as-list-item links)))
     (if no-sort
         (nreverse links)
       (sort links #'string-collate-lessp))))
 
-(defun denote-link--insert-links (files current-file-type &optional id-only no-sort include-date)
+(defun denote-link--insert-links (files current-file-type &optional id-only no-sort)
   "Insert at point a typographic list of links matching FILES.
 
 With CURRENT-FILE-TYPE as a symbol among those specified in variable
@@ -5927,10 +5918,8 @@ default to the Org notation.
 With ID-ONLY as a non-nil value, produce links that consist only
 of the identifier, thus deviating from CURRENT-FILE-TYPE.
 
-Optional NO-SORT is passed to `denote-link--prepare-links'.
-
-Optional INCLUDE-DATE has the same meaning as in `denote-format-link'."
-  (when-let* ((links (denote-link--prepare-links files current-file-type id-only no-sort include-date)))
+Optional NO-SORT is passed to `denote-link--prepare-links'."
+  (when-let* ((links (denote-link--prepare-links files current-file-type id-only no-sort)))
     (dolist (link links)
       (insert link))))
 


### PR DESCRIPTION
It does not appear to be used in the code and it is probably better to configure `denote-link-description-format` to include the date in the link description.

I can provide an example if you want!