### PR TITLE
Ensure sluggification of signature in front matter obey denote-file-name-slug-functions

### DIFF
--- a/README.org
+++ b/README.org
@@ -5172,16 +5172,17 @@ there will be no corresponding prompt.
   as a helper function to construct ~denote-file-name-slug-functions~
   ([[#h:d1e4eb5b-e7f2-4a3b-9243-e1c653817a4a][Custom sluggification to remove non-ASCII characters]]).
 
-#+findex: denote-sluggify
-+ Function ~denote-sluggify~ :: Make =STR= an appropriate slug for
-  file name =COMPONENT= ([[#h:ae8b19a1-7f67-4258-96b3-370a72c43f4e][Sluggification of file name components]]).
-  Apply the function specified in ~denote-file-name-slug-function~ to
-  =COMPONENT= which is one of =title=, =signature=, =keyword=. If the
-  resulting string still contains consecutive =-=,=_= or ~=~, they are
-  replaced by a single occurence of the character, if necessary
-  according to =COMPONENT=. If =COMPONENT= is ~keyword~, remove
-  underscores from =STR= as they are used as the keywords separator in
-  file names.
+#+findex: denote-sluggify-and-apply-rules
++ Function ~denote-sluggify-and-apply-rules~ :: Make =STR= an
+  appropriate slug for file name =COMPONENT=
+  ([[#h:ae8b19a1-7f67-4258-96b3-370a72c43f4e][Sluggification of file name components]]). Apply the function
+  specified in ~denote-file-name-slug-function~ to =COMPONENT= which
+  is one of =title=, =signature=, =keyword=. If the resulting string
+  still contains consecutive =-=,=_= or ~=~, they are replaced by a
+  single occurence of the character, if necessary according to
+  =COMPONENT=. If =COMPONENT= is ~keyword~, remove underscores from
+  =STR= as they are used as the keywords separator in file names. Also
+  enforce the rules of the file-naming scheme.
 
 #+findex: denote-sluggify-keyword
 + Function ~denote-sluggify-keyword~ :: Sluggify =STR= while joining
@@ -5191,9 +5192,10 @@ there will be no corresponding prompt.
 + Function ~denote-sluggify-signature~ :: Make =STR= an appropriate
   slug for signatures ([[#h:ae8b19a1-7f67-4258-96b3-370a72c43f4e][Sluggification of file name components]]).
 
-#+findex: denote-sluggify-keywords
-+ Function ~denote-sluggify-keywords~ :: Sluggify =KEYWORDS=, which is
-  a list of strings ([[#h:ae8b19a1-7f67-4258-96b3-370a72c43f4e][Sluggification of file name components]]).
+#+findex: denote-sluggify-keywords-and-apply-rules
++ Function ~denote-sluggify-keywords-and-apply-rules~ :: Sluggify
+  =KEYWORDS=, which is a list of strings
+  ([[#h:ae8b19a1-7f67-4258-96b3-370a72c43f4e][Sluggification of file name components]]).
 
 #+findex: denote-format-file-name
 + Function ~denote-format-file-name~ :: Format file name. =DIR-PATH=,

--- a/denote.el
+++ b/denote.el
@@ -2283,7 +2283,7 @@ is a list of strings.  FILETYPE is one of the values of variable
          (date-string (denote--format-front-matter-date date filetype))
          (keywords-string (if keywords-value-function (funcall keywords-value-function (denote-sluggify-keywords keywords)) ""))
          (id-string (if id-value-function (funcall id-value-function id) ""))
-         (signature-string (if signature-value-function (funcall signature-value-function (denote-sluggify-signature signature)) ""))
+         (signature-string (if signature-value-function (funcall signature-value-function (denote-sluggify 'signature signature)) ""))
          (new-front-matter (if fm (format fm title-string date-string keywords-string id-string signature-string) "")))
     ;; Remove lines with empty values if the corresponding component
     ;; is not in `denote-front-matter-components-present-even-if-empty-value'.
@@ -3536,7 +3536,7 @@ identifier.  It also returns nil given a nil date or nil keywords."
   (pcase component
     ('title (not (string-empty-p value)))
     ('keywords (not (null value)))
-    ('signature (not (string-empty-p (denote-sluggify-signature value))))
+    ('signature (not (string-empty-p (denote-sluggify 'signature value))))
     ('date (not (null value)))
     ('identifier (not (string-empty-p value)))))
 


### PR DESCRIPTION
The signature in the front matter was always sluggified according to `denote-sluggify-signature` rather than the function specified in `denote-file-name-slug-function`. I fix this here.

I also renamed the function `denote-sluggify` to `denote-sluggify-and-apply-rules` to make it clear that 2 distinct ideas are involved.