### PR TITLE
Implement denote-extra-directories variable

### DIFF
--- a/denote.el
+++ b/denote.el
@@ -5150,7 +5150,9 @@ interpreted as in `denote-directory-files'."
 (defun denote-link-external-file (file file-type description &optional id-only)
   "Like `denote-link', but only considers files in `denote-extra-directories'."
   (interactive
-   (let* ((file (completing-read
+   (let* ((_ (unless denote-extra-directories
+               (user-error "No extra directories defined; customize `denote-extra-directories'")))
+          (file (completing-read
                  "Link to external FILE: "
                  (denote--completion-table
                   'file


### PR DESCRIPTION
Currently, Denote can only link to other files in `denote-directory`. That effectively means every valuable file must be kept in that directory in order to reference it. This is not always desirable or possible. Here I craft a simple solution to the issue, which I hope makes everybody happy: a new variable named `denote-extra-directories`, containing a list of directories with files the user can link to. Any link to an identifier not found in `denote-directory` is then searched among these files and followed if found there.

I created these helper commands:

- `denote-link-external-file`: Like `denote-link`, but only considers files in `denote-extra-directories`.
- `denote-backlinks-extra`: Like `denote-backlinks`, but also considers files in `denote-extra-directories`. A user variable exists so this behaviour is available in `denote-backlinks` too, `denote-backlinks-include-extra-directories`.

I tried to keep things simple. Only links and backlinks are implemented; it's possible to add new functionality on top (such as enabling `denote-grep` and `denote-query` to search in the extra directories), but I wanted to stop here and see if this is the right path to follow.

This should solve issue #228. Pinging @jeanphilippegg as he may have something to say about this.