### PR TITLE
Fix denote--rename-file for files without an identifier

### DIFF
--- a/denote.el
+++ b/denote.el
@@ -4081,7 +4081,7 @@ Respect `denote-rename-confirmations', `denote-save-buffers' and
                        identifier))
          (identifier (cond ((string-empty-p identifier) identifier)
                            ((string= old-identifier identifier) identifier)
-                           ((denote--file-has-backlinks-p file)
+                           ((and (not (string-empty-p old-identifier)) (denote--file-has-backlinks-p file))
                             (user-error "The identifier cannot be modified because the new identifier has backlinks"))
                            (t (funcall denote-get-identifier-function identifier nil))))
          (new-name (denote-format-file-name directory identifier keywords title extension signature))


### PR DESCRIPTION
This fixes #616.

Later, I will also make the other change I mentioned about `denote-get-backlinks`. I will probably just remove `denote-retrieve-filename-identifier-with-error` completely. This can be done later.

On an unrelated note, I think commit 9549d97 should be reverted. The functions `denote-generate-identifier-as-{date/number}` are not user commands and they are also not meant to be called from lisp directly. Even `denote-get-identifier-function` should probably not be used in packages. They are example identifier generation functions and users have to make a function with 2 parameters if they create their own.