### PR TITLE
Various commits

### DIFF
--- a/denote.el
+++ b/denote.el
@@ -2896,7 +2896,7 @@ available id is found."
                         (time-add (date-to-time current-id) 1))))
     current-id))
 
-(defun denote-generate-identifier-as-date (&optional initial-identifier date)
+(defun denote-generate-identifier-as-date (initial-identifier date)
   "Generate an identifier based on DATE.
 
 If INITIAL-IDENTIFIER is not already used, return it.  Else, if it is
@@ -2930,7 +2930,7 @@ If ID is already used, increment it until an available id is found."
       (setq current-id (number-to-string (1+ (string-to-number current-id)))))
     current-id))
 
-(defun denote-generate-identifier-as-number (&optional initial-identifier _date)
+(defun denote-generate-identifier-as-number (initial-identifier _date)
   "Generate an increasing number identifier.
 
 If INITIAL-IDENTIFIER is not already used, return it.  Else, if it is


### PR DESCRIPTION
- Obsolete `denote-retrieve-filename-identifier-with-error`.

- Move code from `denote-make-links-buffer` in new `denote--display-buffer-from-xref-alist`. I also cleaned up the code a bit. There was a comment saying that xref-alist was not always in absolute form, but with `(xref-file-name-display 'abs)`, it should not be true. I also confirmed it by looking at the code of `xref--analyze`.

- I reverted commit 9749d97, as discussed in #617. It would likely be a mistake to call the functions `denote-generate-identifier-as-{date/number} without their 2 parameters, so they are not optional.