### PR TITLE
Custom identifier formats

### DIFF
--- a/denote.el
+++ b/denote.el
@@ -3350,10 +3350,6 @@ instead of that of the parameter."
                        template
                      (or (alist-get template denote-templates) "")))
          (signature (or signature "")))
-    ;; TODO: Remove this when ready to allow custom identifiers.
-    (unless (and (string-match-p denote-date-identifier-regexp identifier)
-                 (date-to-time identifier))
-      (user-error "The identifier must have the format of `denote-date-identifier-format'"))
     (list title keywords file-type directory date identifier template signature)))
 
 ;;;###autoload
@@ -4235,10 +4231,6 @@ Respect `denote-rename-confirmations', `denote-save-buffers' and
                            (t (funcall denote-get-identifier-function identifier nil))))
          (new-name (denote-format-file-name directory identifier keywords title extension signature))
          (max-mini-window-height denote-rename-max-mini-window-height))
-    ;; TODO: Remove this when ready to allow custom identifiers.
-    (unless (and (string-match-p denote-date-identifier-regexp identifier)
-                 (date-to-time identifier))
-      (user-error "The identifier must have the format of `denote-date-identifier-format'"))
     (when (and (file-regular-p new-name)
                (not (string= (expand-file-name file) (expand-file-name new-name))))
       (user-error "The destination file `%s' already exists" new-name))

--- a/denote.el
+++ b/denote.el
@@ -5708,6 +5708,16 @@ alist, such as `denote-backlinks-display-buffer-action'."
                       (denote--display-buffer-from-xref-alist xref-alist buffer-name display-buffer-action)))))
     (display-buffer buffer-name display-buffer-action)))
 
+(defun denote-make-backlinks-buffer (identifier buffer-name display-buffer-action)
+  "Create links' buffer called BUFFER-NAME for IDENTIFIER.
+
+Optional DISPLAY-BUFFER-ACTION is a `display-buffer' action and
+concomitant alist, such as `denote-backlinks-display-buffer-action'."
+  (let* ((xref-alist (denote-retrieve-xref-alist-for-backlinks identifier)))
+    (unless xref-alist
+      (error "No matches for identifier `%s'" identifier))
+    (denote--display-buffer-from-xref-alist xref-alist buffer-name display-buffer-action)))
+
 ;; NOTE 2025-03-24: The `&rest' is there because we used to have an
 ;; extra SHOW-CONTEXT parameter.  This way we do not break anybody's
 ;; code, even if we slightly modify the behaviour.

--- a/denote.el
+++ b/denote.el
@@ -6020,10 +6020,10 @@ Place the buffer below the current window or wherever the user option
   (interactive)
   (if-let* ((file buffer-file-name))
       (if-let* ((identifier (denote-retrieve-filename-identifier file)))
-          (funcall denote-query-links-buffer-function
-                   identifier nil
-                   (denote--backlinks-get-buffer-name file identifier)
-                   denote-backlinks-display-buffer-action)
+          (denote-make-backlinks-buffer
+           identifier
+           (denote--backlinks-get-buffer-name file identifier)
+           denote-backlinks-display-buffer-action)
         (user-error "The current file does not have a Denote identifier"))
     (user-error "Buffer `%s' is not associated with a file" (current-buffer))))
 

--- a/denote.el
+++ b/denote.el
@@ -6011,9 +6011,7 @@ use the ID."
 (defun denote-backlinks ()
   "Produce a buffer with backlinks to the current note.
 
-Show the names of files linking to the current file.  Include the
-context of each link if the user option `denote-backlinks-show-context'
-is non-nil.
+Show the names of files linking to the current file.
 
 Place the buffer below the current window or wherever the user option
 `denote-backlinks-display-buffer-action' specifies."

--- a/denote.el
+++ b/denote.el
@@ -6041,7 +6041,7 @@ Also see `denote-get-links'."
   (when-let* ((current-file (or file (buffer-file-name)))
               (id (or (denote-retrieve-filename-identifier current-file)
                       (user-error "The file does not have a Denote identifier"))))
-    (delete current-file (denote-retrieve-files-xref-query id))))
+    (mapcar #'car (denote-retrieve-xref-alist-for-backlinks id))))
 
 ;; TODO 2024-09-04: Instead of using `denote-get-backlinks' we
 ;; should have a function that does not try to find all backlinks but

--- a/denote.el
+++ b/denote.el
@@ -2181,6 +2181,7 @@ Consult the `denote-file-types' for how this is used."
      :date-key-regexp "^#\\+date\\s-*:"
      :date-value-function denote-date-org-timestamp
      :date-value-reverse-function denote-extract-date-from-front-matter
+     :link-retrieval-format "[denote:%VALUE%]"
      :link denote-org-link-format
      :link-in-context-regexp denote-org-link-in-context-regexp)
     (markdown-yaml
@@ -2201,6 +2202,7 @@ Consult the `denote-file-types' for how this is used."
      :date-key-regexp "^date\\s-*:"
      :date-value-function denote-date-rfc3339
      :date-value-reverse-function denote-extract-date-from-front-matter
+     :link-retrieval-format "(denote:%VALUE%)"
      :link denote-md-link-format
      :link-in-context-regexp denote-md-link-in-context-regexp)
     (markdown-toml
@@ -2221,6 +2223,7 @@ Consult the `denote-file-types' for how this is used."
      :date-key-regexp "^date\\s-*="
      :date-value-function denote-date-rfc3339
      :date-value-reverse-function denote-extract-date-from-front-matter
+     :link-retrieval-format "(denote:%VALUE%)"
      :link denote-md-link-format
      :link-in-context-regexp denote-md-link-in-context-regexp)
     (text
@@ -2241,6 +2244,7 @@ Consult the `denote-file-types' for how this is used."
      :date-key-regexp "^date\\s-*:"
      :date-value-function denote-date-iso-8601
      :date-value-reverse-function denote-extract-date-from-front-matter
+     :link-retrieval-format "[denote:%VALUE%]"
      :link denote-org-link-format
      :link-in-context-regexp denote-org-link-in-context-regexp))
   "Alist of variable `denote-file-type' and their format properties.
@@ -2288,6 +2292,9 @@ PROPERTY-LIST is a plist that consists of the following elements:
 - `:keywords-value-reverse-function' is the function used to
   retrieve the keywords' value from the front matter.  It
   performs the reverse of the `:keywords-value-function'.
+
+- `:link-retrieval-format' is a string, or variable holding a string,
+  that specifies the retrieval format of a link.
 
 - `:link' is a string, or variable holding a string, that
   specifies the format of a link.  See the variables
@@ -2409,6 +2416,15 @@ this list for new note creation.  The default is `org'.")
   (plist-get
    (alist-get file-type denote-file-types)
    :date-value-reverse-function))
+
+(defun denote--link-retrieval-format (file-type)
+  "Return link retrieval format based on FILE-TYPE."
+  (let ((prop (plist-get
+               (alist-get file-type denote-file-types)
+               :link-retrieval-format)))
+    (if (symbolp prop)
+        (symbol-value prop)
+      prop)))
 
 (defun denote--link-format (file-type)
   "Return link format extension based on FILE-TYPE."


### PR DESCRIPTION
Hello Prot!

In this pull request, I made the final changes to allow custom
identifier formats.

For your info (and anyone interested), the challenge was to find the
backlinks correctly. I needed to be able to retrieve links according
to the format of each supported file type. For example, for org, I
need to look for "[denote:some-identifier]" instead of only
"some-identifier". This is because if an id is "11", we cannot just
look for "11". We also cannot just look for "denote:11" because it
will also match "denote:11111".

I did the requisite changes. In fact, I also created the function
`denote--get-all-backlinks` that may be useful eventually. Right now,
each call to `denote-backlinks` reads all notes. With
`denote--get-all-backlinks`, we scan all files once and we have ALL
backlinks, for each identifier. We may want to cache this.

### Important notes

- Greping is not done by Xref anymore. Instead, it is done by calling
  the existing `denote-link--collect-identifiers` (which should
  probably be renamed) on each note. This may be slower than before
  depending on how xref is working. If there are performance issues,
  this PR is easy to revert. So it is probably best to wait a little
  before telling users that identifiers can have any format (or you
  may want to keep commit f704b49 for later). I still use Xref to
  display the final results, so things should still look as before.

- `denote-backlinks` does not use `denote-query-buffer-function`
  anymore. We cannot just grep for the identifier if identifiers can
  be anything, as explained above.

- Only supported file types will appear in backlinks buffer. This is
  probably acceptable and as intended.

- A note can now link to itself and should appear in the backlinks
  buffer.

- `denote-grep/query` should be unaffected by these changes.