### PR TITLE
Various adjustments

### DIFF
--- a/denote.el
+++ b/denote.el
@@ -793,7 +793,8 @@ even an empty string to not have any such prefix."
   :group 'denote)
 
 (defcustom denote-file-name-slug-functions
-  '((title . denote-sluggify-title)
+  '((identifier . identity)
+    (title . denote-sluggify-title)
     (signature . denote-sluggify-signature)
     (keyword . denote-sluggify-keyword))
   "Specify the method Denote uses to format the components of the file name.
@@ -801,9 +802,9 @@ even an empty string to not have any such prefix."
 The value is an alist where each element is a cons cell of the
 form (COMPONENT . METHOD).
 
-- The COMPONENT is an unquoted symbol among `title', `signature',
-  `keyword' (notice the absence of `s', see below), which
-  refers to the corresponding component of the file name.
+- The COMPONENT is an unquoted symbol among `identifier', `title',
+  `signature', `keyword' (notice the absence of `s', see below),
+  which refers to the corresponding component of the file name.
 
 - The METHOD is the function to be used to format the given
   component.  This function should take a string as its parameter
@@ -816,8 +817,8 @@ form (COMPONENT . METHOD).
 Note that the `keyword' function is also applied to the keywords
 of the front matter.
 
-By default, if a function is not specified for a component, we
-use `denote-sluggify-title', `denote-sluggify-keyword' and
+By default, if a function is not specified for a component, we use
+`identity', `denote-sluggify-title', `denote-sluggify-keyword' and
 `denote-sluggify-signature'.
 
 Remember that deviating from the default file-naming scheme of Denote
@@ -1124,11 +1125,11 @@ a single one in str, if necessary according to COMPONENT."
   "Make STR an appropriate slug for file name COMPONENT.
 
 Apply the function specified in `denote-file-name-slug-function' to
-COMPONENT which is one of `title', `signature', `keyword'.  If the
-resulting string still contains consecutive -, _, =, or @, they are
-replaced by a single occurence of the character, if necessary according
-to COMPONENT.  If COMPONENT is `keyword', remove underscores from STR as
-they are used as the keywords separator in file names.
+COMPONENT which is one of `identifier', `title', `signature', `keyword'.
+If the resulting string still contains consecutive -, _, =, or @, they
+are replaced by a single occurence of the character, if necessary
+according to COMPONENT.  If COMPONENT is `keyword', remove underscores
+from STR as they are used as the keywords separator in file names.
 
 Also enforce the rules of the file-naming scheme."
   (let* ((slug-function (alist-get component denote-file-name-slug-functions))
@@ -1139,7 +1140,8 @@ Also enforce the rules of the file-naming scheme."
                            "_" ""
                            (funcall (or slug-function #'denote-sluggify-keyword) str)))
                          ((eq component 'identifier)
-                          (denote--valid-identifier str))
+                          (denote--valid-identifier
+                           (funcall (or slug-function #'identity) str)))
                          ((eq component 'signature)
                           (funcall (or slug-function #'denote-sluggify-signature) str)))))
     (denote--trim-right-token-characters

--- a/denote.el
+++ b/denote.el
@@ -1324,14 +1324,14 @@ Avoids traversing dotfiles (unconditionally) and whatever matches
 
 (defun denote-directory-get-files ()
   "Return list with full path of valid files in variable `denote-directory'.
-Consider files that satisfy `denote-file-has-identifier-p' and
+Consider files that satisfy `denote-file-has-denoted-filename-p' and
 are not backups."
   (mapcar
    #'expand-file-name
    (seq-filter
     (lambda (file)
       (and (file-regular-p file)
-           (denote-file-has-identifier-p file)
+           (denote-file-has-denoted-filename-p file)
            (not (denote--file-excluded-p file))
            (not (backup-file-name-p file))))
     (denote--directory-all-files-recursively))))

--- a/denote.el
+++ b/denote.el
@@ -3052,15 +3052,9 @@ This is a reference function for `denote-get-identifier-function'."
 (defun denote--find-first-unused-id-as-number (id)
   "Return the first unused id starting at ID.
 If ID is already used, increment it until an available id is found."
-  (let ((current-id id)
-        (iteration 0))
-    (while (gethash current-id denote-used-identifiers)
-      ;; Prevent infinite loop
-      (setq iteration (1+ iteration))
-      (when (>= iteration 10000)
-        (user-error "A unique identifier could not be found"))
-      (setq current-id (number-to-string (1+ (string-to-number current-id)))))
-    current-id))
+  (while (gethash id denote-used-identifiers)
+    (setq id (number-to-string (1+ (string-to-number id)))))
+  id)
 
 (defun denote-generate-identifier-as-number (initial-identifier _date)
   "Generate an increasing number identifier.

--- a/denote.el
+++ b/denote.el
@@ -3072,13 +3072,21 @@ Else, use the first unused number starting from 1.
 
 This is a reference function for `denote-get-identifier-function'."
   (let ((denote-used-identifiers (or denote-used-identifiers (denote--get-all-used-ids))))
-    (cond ((and initial-identifier
+    (cond (;; Always use the supplied initial-identifier if possible,
+           ;; regardless of format.
+           (and initial-identifier
                 (not (gethash initial-identifier denote-used-identifiers)))
            initial-identifier)
-          ((and initial-identifier
+          (;; If the supplied initial-identifier is already used, but
+           ;; it has the right format, make is unique.
+           (and initial-identifier
                 (string-match-p "[1-9][0-9]*" initial-identifier))
            (denote--find-first-unused-id-as-number initial-identifier))
-          (t
+          (;; Else, the supplied initial-identifier is nil or it is
+           ;; already used or it does not match the supplied
+           ;; format. Ignore it and generate a valid identifier with
+           ;; the right format.
+           t
            (denote--find-first-unused-id-as-number "1")))))
 
 (defvar denote-command-prompt-history nil

--- a/denote.el
+++ b/denote.el
@@ -418,6 +418,12 @@ in the front matter template."
           (const :tag "Date" date)
           (const :tag "Identifier" identifier)))
 
+(defcustom denote-identifier-delimiter-always-present-in-file-name nil
+  "Specify if file names always contain the identifier delimiter."
+  :group 'denote
+  :package-version '(denote . "4.1.0")
+  :type 'boolean)
+
 (defcustom denote-sort-keywords t
   "Whether to sort keywords in new files.
 
@@ -2858,7 +2864,8 @@ which case it is not added to the base file name."
       (error "There should be at least one file name component"))
     (setq file-name (concat file-name extension))
     ;; Do not prepend identifier with @@ if it is the first component and has the format 00000000T000000.
-    (when (and (string-prefix-p "@@" file-name)
+    (when (and (not denote-identifier-delimiter-always-present-in-file-name)
+               (string-prefix-p "@@" file-name)
                (string-match-p (concat "\\`" denote-date-identifier-regexp "\\'") id))
       (setq file-name (substring file-name 2)))
     (concat dir-path file-name)))

--- a/denote.el
+++ b/denote.el
@@ -1220,6 +1220,9 @@ For our purposes, a note must satisfy `file-regular-p' and
 `denote-filename-is-note-p'."
   (and (file-regular-p file) (denote-filename-is-note-p file)))
 
+(make-obsolete 'denote-filename-is-note-p nil "4.1.0")
+(make-obsolete 'denote-file-is-note-p nil "4.1.0")
+
 (defun denote-file-has-denoted-filename-p (file)
   "Return non-nil if FILE respects the file-naming scheme of Denote.
 
@@ -3006,7 +3009,10 @@ If DATE is nil or an empty string, return nil."
          (lambda (buffer)
            (when-let* (((buffer-live-p buffer))
                        (file (buffer-file-name buffer))
-                       ((denote-filename-is-note-p file)))
+                       ((denote-file-is-in-denote-directory-p file))
+                       ((denote-file-has-supported-extension-p file))
+                       ((denote-file-has-denoted-filename-p file))
+                       ((denote-file-has-identifier-p file)))
              file))
          (buffer-list))))
 
@@ -6323,7 +6329,9 @@ To be used as a `thing-at' provider."
   "Enable `denote-fontify-links-mode' in a denote file unless in `org-mode'."
   (when (and buffer-file-name
              (not (derived-mode-p 'org-mode))
-             (denote-file-is-note-p buffer-file-name))
+             (denote-file-is-in-denote-directory-p buffer-file-name)
+             (denote-file-has-supported-extension-p buffer-file-name)
+             (denote-file-has-denoted-filename-p buffer-file-name))
     (denote-fontify-links-mode)))
 
 ;;;###autoload
@@ -6743,7 +6751,9 @@ Optional INTERACTIVE? is used by `org-store-link'.
 Also see the user option `denote-org-store-link-to-heading'."
   (when interactive?
     (when-let* ((file (buffer-file-name))
-                ((denote-file-is-note-p file))
+                ((file-regular-p file))
+                ((denote-file-is-in-denote-directory-p file))
+                ((denote-file-has-denoted-filename-p file))
                 (file-id (denote-retrieve-filename-identifier file))
                 (description (denote-get-link-description file)))
       (let ((heading-links (and denote-org-store-link-to-heading

--- a/denote.el
+++ b/denote.el
@@ -1025,19 +1025,13 @@ returns the first directory."
 
 (make-obsolete 'denote-directory 'denote-directories "4.1.0")
 
-;; TODO: Review and fix the features listed in the docstring below before
-;; making this a user option.
 (defvar denote-generate-identifier-automatically t
   "Make creation and renaming commands automatically create and identifier.
 
 This applies when a note is created or renamed.  The default is to
 always create an identifier automatically.
 
-Valid values are: t, nil, `on-creation', and `on-rename'.
-
-IMPORTANT: Some features may not work with notes that do not have an
-identifier.  For example, backlinks do not contain files without an
-identifier.")
+Valid values are: t, nil, `on-creation', and `on-rename'.")
 
 (defvar denote-accept-nil-date nil
   "Make creation and renaming commands use `current-time' when date is nil.")

--- a/denote.el
+++ b/denote.el
@@ -2859,7 +2859,7 @@ which case it is not added to the base file name."
     (setq file-name (concat file-name extension))
     ;; Do not prepend identifier with @@ if it is the first component and has the format 00000000T000000.
     (when (and (string-prefix-p "@@" file-name)
-               (string-match-p (concat "\\`" denote-date-identifier-regexp "\\'") id)) ; This is always true for now.
+               (string-match-p (concat "\\`" denote-date-identifier-regexp "\\'") id))
       (setq file-name (substring file-name 2)))
     (concat dir-path file-name)))
 


### PR DESCRIPTION
These are small cleanups following my last pull request. With these
changes, identifiers are now completely optional and arbitrary, like
other file name components.

### Add `denote-identifier-delimiter-always-present-in-file-name`

The default is `nil`. The use-case I have in mind is the one in your
wishlist in the manual. Say a user decide to configure their
identifier format to be "20250101W000000" on a Wednesday and
"20250102T000000" on a Thursday. It may look odd if notes on Thursdays
lack the identifier delimiter. With this new user option, the
delimiter can be made always present.

### Add identifier sluggification

All file name components can now be sluggified.

### Add `has-identifier` parameter to `denote-directory-files`

This makes it so `denote-directory-files` may include notes that
respect Denote's file naming scheme, but do not have an identifier.
Packages will have to decide whether it makes sense to include them or
not.

I have adjusted the code so that backlinks can include such files.

I believe this was the final fix in order to say that identifiers are
optional.

### Mark `denote-file(name)-is-note-p` as obsolete

It is probably better to be more deliberate as to the conditions that
are needed depending on the situation.