### PR TITLE
Fix trimming of Org links in `denote-link-ol-follow'

### DIFF
--- a/denote.el
+++ b/denote.el
@@ -6849,7 +6849,7 @@ query of file contents or file names (see the commands
 
 Uses the function `denote-directory' to establish the path to the file."
   (if-let* ((match (denote-link--ol-resolve-link-to-target link))
-            (_ (file-exists-p (string-trim-right match ":\\{2\\}.*"))))
+            (_ (file-exists-p (string-trim-right match "::.*"))))
       (org-link-open-as-file match nil)
     (denote--act-on-query-link match)))
 


### PR DESCRIPTION
The current regexp only checks for a single colon, whereas search options in Org links are always followed by a double colon.

This is specially problematic in the Android port of Emacs, where external directories accessible to the Emacs app (see ```(info "(emacs) Android Document Providers")```) have paths like
```
/content/storage/com.android.externalstorage.documents/primary:emacs/denote
```
which get truncated by this function. If ```denote-directory``` is in one these directories, it makes it impossible to open links to other notes.