### PR TITLE
Make rename buffer check early

### DIFF
--- a/denote.el
+++ b/denote.el
@@ -7237,7 +7237,9 @@ This is called if `denote-rename-buffer-rename-function' is nil."
 (defun denote-rename-buffer-rename-function-or-fallback ()
   "Call `denote-rename-buffer-function' or its fallback to rename with title.
 Add this to `find-file-hook' and `denote-after-new-note-hook'."
-  (funcall (or denote-rename-buffer-function #'denote-rename-buffer--fallback)))
+  (when-let* ((file (buffer-file-name))
+              ((denote-file-has-identifier-p file)))
+    (funcall (or denote-rename-buffer-function #'denote-rename-buffer--fallback))))
 
 ;;;###autoload
 (define-minor-mode denote-rename-buffer-mode


### PR DESCRIPTION
When users customize `denote-rename-buffer-function' without checking whether the current buffer is a Denote buffer, `find-file-hook' may trigger unintended renames.

Because `denote-rename-buffer' accepts an optional buffer argument, the Denote buffer check must be performed twice.

* (denote-rename-buffer-rename-function-or-fallback):