### PR TITLE
Fix denote--define-retrieve-front-matter not reusing opened buffer

### DIFF
--- a/denote.el
+++ b/denote.el
@@ -2645,14 +2645,13 @@ Subroutine of `denote--file-with-temp-buffer'."
          (file-exists (file-exists-p file))
          (buffer-modified (buffer-modified-p buffer)))
     (cond
-     ((or (and file-exists
-               buffer
-               (not buffer-modified)
-               (not (eq buffer-modified 'autosaved)))
-          (and file-exists (not buffer)))
-      (cons #'insert-file-contents file))
-     (buffer
+     ((and file-exists
+           buffer
+           (not buffer-modified))
       (cons #'insert-buffer buffer))
+     ((and file-exists
+           (or (null buffer) buffer-modified))
+      (cons #'insert-file-contents file))
      ;; (t
      ;;  (error "Cannot find anything about file `%s'" file))
      )))


### PR DESCRIPTION
In earlier commits, denote-rename-buffer could open the same file multiple times when retrieving front matter, as described in https://github.com/protesilaos/denote/issues/652 .

This occurred because the subroutine denote--file-with-temp-buffer-subr, used in the definition of denote--define-retrieve-front-matter, contained incorrect conditional logic. As a result, files were reopened instead of reusing already opened buffers.

Fixes: https://github.com/protesilaos/denote/issues/652