### PR TITLE
Fix docstring of denote-query-extract-title

### DIFF
--- a/denote.el
+++ b/denote.el
@@ -5758,7 +5758,7 @@ Used only by `denote-query-extract-title'."
 
 When no title is found, return title found in FILE name.
 
-When that doesn't work, return `denote-grep-untitled-string'.
+When that doesn't work, return `denote-query-untitled-string'.
 
 Intended to be used as `denote-query-format-heading-function'."
   (if-let* ((type (denote-filetype-heuristics file))


### PR DESCRIPTION
Docstring says function returns `denote-grep-untitled-string`, but it actually returns `denote-query-untitled-string`. This commit corrects the name of the variable in the docstring.