### PR TITLE
[Feature Proposal] Add denote-link-or-create-with-command

### DIFF
--- a/denote.el
+++ b/denote.el
@@ -6780,6 +6780,9 @@ This command is meant to be used from a Dired buffer."
     ["Link to existing note or newly created one" denote-link-or-create
      :help "Insert a link to an existing file, else create it and link to it"
      :enable (derived-mode-p 'text-mode)]
+    ["Link to existing note or newly created one with the chosen command" denote-link-or-create-with-command
+     :help "Insert a link to an existing file, else create it with the given command and link to it"
+     :enable (derived-mode-p 'text-mode)]
     ["Create note in the background and link to it directly" denote-link-after-creating
      :help "Create new note and link to it from the current file"
      :enable (derived-mode-p 'text-mode)]


### PR DESCRIPTION
This PR proposes adding the command `denote-link-or-create-with-command` as the "with-command" complement to `denote-link-or-create`.

**Motivation:**
The command `denote-link-or-create` is a convenient way to link to a note that may or may not already exist, without having to first run one command to search existing notes, finding the relevant note does not exist yet, cancel the command, and then run another command like `denote-link-after-creating`. However, unlike `denote-link-after-creating` or `denote-open-or-create`, there is no "with-command" version of `denote-link-or-create` for users who prefer to create their notes via a note-making command from `denote-commands-for-new-notes`.

As I desired this functionality, I created the `denote-link-or-create-with-command` command for myself, and am proposing it here in case it is desired for inclusion in the denote project.

**Background:**
This command seems to have been planned at one point, having been added as a menu bar item in commit 69391aa. It was later pointed out in https://github.com/protesilaos/denote/issues/543#issuecomment-2635669489 that `denote-link-or-create-with-command` did not actually exist, and reference to it in the menu bar was removed in commit 212a1b3 with the commit message stating that "We deleted it at some point, but did not remove everything." However, from my own searching of the git logs and the github issue tracker, I could not actually find evidence that the command ever did exist, except in references in the documentation. I mention this only to point out that I could not find record of a clearly deliberate decision to exclude such a command from denote in a permanent sense. Therefore, I decided to propose here it despite the fact that it has in a certain sense been removed from denote in the past. Of course, it's easily possible I have missed or am unaware of something, and so if a decision has already been made against the inclusion of this command, or it is just not desired anyway, please feel free to close this PR.

**Technical considerations:**
I have made `denote-link-or-create-with-command` interactive-only (similarly to `denote-open-or-create-with-command`) for two reasons:
1. `denote-link` already exists for programmatically linking to an already existing note via an elisp call.
2. All the `denote-commands-for-new-notes` are interactive-only anyway.

If you would prefer that this command be able to be called via elisp as well as interactively, however, I would be happy to make the required change to the PR.

**Edit:** Also, I have in the past signed the FSF copyright assignment forms for contributing to Emacs. If you need me to provide any sort of details/confirmation of identity via email just let me know!