### PR TITLE
Fix error when following non-Denote Markdown links

### DIFF
--- a/denote.el
+++ b/denote.el
@@ -6367,10 +6367,11 @@ Return either nil or a list whose elements are two cons cells:
 This is the subroutine of `denote-link-open-at-point' and
 `denote-link-open-at-mouse'."
   (pcase-let* ((data (denote--link-at-point-get-data position))
-               (`(,target . ,_) (car data)))
-    (if-let* ((path (denote-get-path-by-id target)))
-        (funcall denote-open-link-function path)
-      (denote--act-on-query-link target))))
+               (`(,target . ,_) (car data))
+               (path (denote-get-path-by-id target)))
+    (cond
+     (path (funcall denote-open-link-function path))
+     (target (denote--act-on-query-link target)))))
 
 (defun denote-link-open-at-point ()
   "Open Denote link at point."


### PR DESCRIPTION
When following links in markdown-mode that are to non-Denote resources like URLs, you would see the error:

    Cannot open ‘nil’ of unknown link type

That is because Denote adds `denote-link-markdown-follow` to `markdown-follow-link-functions`, which eventually calls `denote--act-on-query-link` with a nil value.

To solve this, we return nil from `denote-link-markdown-follow` when we do not know how to handle the link. That lets markdown-mode try its link handling. Per the `markdown-follow-link-functions` documentation, we should "return non-nil if [we] followed the link, or nil if not."

One potential issue is that the function I modified, `denote--link-open-at-point-subr`, is used by `denote-link-open-at-point` and `denote-link-open-at-mouse` which may not be exclusively used for markdown-mode. This change may cause issues in other modes.