### PR TITLE
denote-open-or-create errors in directories with oddly-named files (#707)

### DIFF
--- a/denote.el
+++ b/denote.el
@@ -1492,10 +1492,9 @@ there.")
 
 (defun denote-file-prompt--format-identifier (file)
   "Return identifier of FILE for `denote-file-prompt-affixate'."
-  (let* ((identifier (denote-retrieve-filename-identifier file))
-         (date-or-id (or (ignore-errors (denote-id-to-date identifier)) identifier))
-         (propertized (propertize date-or-id 'face 'completions-annotations)))
-    (format "%s " propertized)))
+  (when-let* ((identifier (denote-retrieve-filename-identifier file))
+              (date-or-id (or (ignore-errors (denote-id-to-date identifier)) identifier)))
+    (format "%s " (propertize date-or-id 'face 'completions-annotations))))
 
 (defun denote-file-prompt--format-keywords-and-signature (file)
   "Return keywords and signature of FILE for `denote-file-prompt-affixate'."

--- a/denote.el
+++ b/denote.el
@@ -906,16 +906,16 @@ The note's ID is derived from the date and time of its creation.")
 (defconst denote-date-identifier-regexp "\\([0-9]\\{8\\}\\)\\(T[0-9]\\{6\\}\\)"
   "Regular expression to match `denote-date-identifier-format'.")
 
-(defconst denote-identifier-regexp "@@\\([^.]*?\\)\\(==.*\\|--.*\\|__.*\\|@@.*\\|\\..*\\)*$"
+(defconst denote-identifier-regexp "@@\\([^.]+?\\)\\(==.*\\|--.*\\|__.*\\|@@.*\\|\\..*\\)*$"
   "Regular expression to match the IDENTIFIER field in a file name.")
 
-(defconst denote-signature-regexp "==\\([^.]*?\\)\\(==.*\\|--.*\\|__.*\\|@@.*\\|\\..*\\)*$"
+(defconst denote-signature-regexp "==\\([^.]+?\\)\\(==.*\\|--.*\\|__.*\\|@@.*\\|\\..*\\)*$"
   "Regular expression to match the SIGNATURE field in a file name.")
 
-(defconst denote-title-regexp "--\\([^.]*?\\)\\(==.*\\|__.*\\|@@.*\\|\\..*\\)*$"
+(defconst denote-title-regexp "--\\([^.]+?\\)\\(==.*\\|__.*\\|@@.*\\|\\..*\\)*$"
   "Regular expression to match the TITLE field in a file name.")
 
-(defconst denote-keywords-regexp "__\\([^.]*?\\)\\(==.*\\|--.*\\|__.*\\|@@.*\\|\\..*\\)*$"
+(defconst denote-keywords-regexp "__\\([^.]+?\\)\\(==.*\\|--.*\\|__.*\\|@@.*\\|\\..*\\)*$"
   "Regular expression to match the KEYWORDS field in a file name.")
 
 (make-obsolete-variable


### PR DESCRIPTION
Calling `denote-open-or-create` (or any command that uses the file prompt) can error with `Wrong type argument: stringp, nil` when the `denote-directory` contains files whose names happen to be a bare denote separator followed by an extension: `__.js`, `--.org`, `==.org`, `@@.org`. (lodash ships `node_modules/lodash/fp/__.js`, so an accidental lodash checkout under a denote-directory is enough to trip it)

Reported in #707, where it surfaces under helm as `helm-M-x-execute-command: Wrong type argument: stringp, nil`.

The fix is two-fold:

1. **Tighten the field regexps.** `denote-{identifier,signature,title,keywords}-regexp` used a zero-or-more lazy capture (`[^.]*?`), so `__.js` and friends matched as denote files with an empty field. Switching to `[^.]+?` requires at least one character in the field, so these names stop being recognised as denote notes and stop showing up as file-prompt candidates.

2. **Don't assume the field is present** in `denote-file-prompt--format-identifier`. Even with the regex tightened, the function shouldn't feed nil to `propertize` if the file has no identifier — it now returns nil, which `denote-file-prompt-affixate` already handles via `(or … "")`.

Fixes #707.