### PR TITLE
Fix denote: link previews during Org mode startup in silos

### DIFF
--- a/denote.el
+++ b/denote.el
@@ -7097,11 +7097,12 @@ backend."
 ;;;###autoload
 (defun denote-link-preview-file (overlay link-target link-data)
   "Use `org-link-preview-file' for OVERLAY, LINK-TARGET, and LINK-DATA.
-Unless the LINK-TARGET has search options, then try to produce a preview.
+Produce no preview if LINK-TARGET has search options or does not
+resolve to a file.
 
 For more details, refer to the documentation of `org-link-set-parameters'."
   (pcase-let* ((`(,path ,_ ,file-search) (denote-link--ol-resolve-link-to-target link-target :full-data)))
-    (unless file-search
+    (when (and path (not file-search))
       (org-link-preview-file overlay path link-data))))
 
 ;; The `eval-after-load' part with the quoted lambda is adapted from

--- a/denote.el
+++ b/denote.el
@@ -961,25 +961,50 @@ Make any parent directories as well."
         (mapcar get-dir directory-or-directories)
       (list (funcall get-dir directory-or-directories)))))
 
+(declare-function hack-dir-local--get-variables "files" (&optional predicate))
+
+(defun denote-directories--dir-local-value ()
+  "Return the dir-local value of variable `denote-directory', if any.
+Read the value directly from the directory-local variables data, so
+that it is available even before `hack-local-variables' has applied it.
+Major mode bodies run before directory-local variables are applied to
+the buffer, so anything that resolves Denote paths during mode setup,
+such as Org link previews at startup, would otherwise see the wrong
+value inside a silo.
+
+Return nil if the variable `denote-directory' is buffer-local or
+dynamically bound, if directory-local variables are disabled, or if
+they do not specify a value for the variable `denote-directory'."
+  (when (and (not (local-variable-p 'denote-directory))
+             (eq denote-directory (default-toplevel-value 'denote-directory))
+             (fboundp 'hack-dir-local--get-variables))
+    (cdr (assq 'denote-directory
+               (cdr (hack-dir-local--get-variables))))))
+
 (defun denote-directories ()
   "Return path of variable `denote-directory' as a proper directory.
 If the variable `denote-directory' is set to a list of file paths,
 return the list with each element expanded to be a directory.  Create
 any directories and their parents, if needed.
 
+A directory-local value of the variable `denote-directory' is honored
+even when it has not yet been applied to the buffer, as is the case
+while the major mode is still initializing.
+
 Custom Lisp code can `let' bind the variable `denote-directory'
 to override what this function returns."
-  (if-let* (((or (eq denote-directory 'default-directory) (eq denote-directory 'local)))
-            (silo-dir (denote--default-directory-is-silo-p)))
-      (progn
-        (display-warning
-         'denote
-         "Silo value must be a string; `local' or `default-directory' are obsolete"
-         :error)
-        (list silo-dir))
-    (let ((denote-directories (denote-directories--get-paths denote-directory)))
-      (denote-directories--make-paths denote-directories)
-      denote-directories)))
+  (let ((denote-directory (or (denote-directories--dir-local-value) denote-directory)))
+    (if-let* (((or (eq denote-directory 'default-directory) (eq denote-directory 'local)))
+              (silo-dir (denote--default-directory-is-silo-p)))
+        (progn
+          (display-warning
+           'denote
+           "Silo value must be a string; `local' or `default-directory' are obsolete"
+           :error)
+          (list silo-dir))
+      (let ((denote-directories (denote-directories--get-paths denote-directory)))
+        (denote-directories--make-paths denote-directories)
+        denote-directories))))
 
 (defun denote-has-single-denote-directory-p ()
   "Return non-nil if the variable `denote-directory' is a single item."

--- a/tests/denote-test.el
+++ b/tests/denote-test.el
@@ -95,6 +95,32 @@ Also see `denote-test--denote--make-denote-directory',
     (should (and (seq-every-p #'file-directory-p denote-directory)
                  (seq-every-p #'file-name-absolute-p denote-directory)))))
 
+(ert-deftest dt-denote-directories--dir-local-value ()
+  "Test that an unapplied dir-local `denote-directory' is honored.
+Directory-local variables are applied only after the major mode is
+initialized, so `denote-directories' reads the dir-local value directly
+in that window.  A dynamic binding or a buffer-local value of the
+variable `denote-directory' still takes precedence."
+  (skip-unless (fboundp 'hack-dir-local--get-variables))
+  (let* ((directory (file-name-as-directory
+                     (expand-file-name "denote-test-silo" temporary-file-directory)))
+         (silo (file-name-as-directory (expand-file-name "notes" directory))))
+    (unwind-protect
+        (progn
+          (make-directory directory :parents)
+          (with-temp-file (expand-file-name ".dir-locals.el" directory)
+            (insert (format "((nil . ((denote-directory . %S))))" silo)))
+          (with-temp-buffer
+            (setq default-directory directory)
+            (should (equal (denote-directories) (list silo)))
+            (let ((denote-directory "/tmp/denote-test-notes"))
+              (should (equal (denote-directories)
+                             (denote-directories--get-paths denote-directory))))
+            (setq-local denote-directory "/tmp/denote-test-notes")
+            (should (equal (denote-directories)
+                           (denote-directories--get-paths denote-directory)))))
+      (delete-directory directory :recursive))))
+
 (ert-deftest dt-denote-sluggify-title ()
   "Test that `denote-sluggify-title' removes punctuation from the string.
 Concretely, remove anything specified in `denote-sluggify-title'."

--- a/tests/denote-test.el
+++ b/tests/denote-test.el
@@ -121,6 +121,19 @@ variable `denote-directory' still takes precedence."
                            (denote-directories--get-paths denote-directory)))))
       (delete-directory directory :recursive))))
 
+(ert-deftest dt-denote-link-preview-file ()
+  "Test that `denote-link-preview-file' handles unresolvable targets.
+An error here would abort the setup of `org-mode' entirely when link
+previews are enabled at startup."
+  (let ((denote-directory (file-name-as-directory
+                           (expand-file-name "denote-test-preview" temporary-file-directory))))
+    (unwind-protect
+        (with-temp-buffer
+          (should-not
+           (denote-link-preview-file
+            (make-overlay (point-min) (point-min)) "00000000T000000" nil)))
+      (delete-directory denote-directory :recursive))))
+
 (ert-deftest dt-denote-sluggify-title ()
   "Test that `denote-sluggify-title' removes punctuation from the string.
 Concretely, remove anything specified in `denote-sluggify-title'."


### PR DESCRIPTION
Follow-up to the `:preview` support from #317. With
`org-startup-with-link-previews` enabled, previews of `denote:` links
fail in two ways when the notes live in a silo (a dir-local
`denote-directory`).

## Problem

- Major mode bodies run before directory-local variables are applied:
  `run-mode-hooks` calls `hack-local-variables` only after the mode
  hooks. Org renders startup link previews inside the `org-mode` body,
  so `denote-directories` resolves identifiers against the global
  `denote-directory` instead of the silo's dir-local value.
- When an identifier does not resolve, `denote-link-preview-file`
  passes nil to `org-link-preview-file`, which signals
  `wrong-type-argument`. During startup previews this aborts the
  entire `org-mode` setup, leaving the buffer half-initialized with
  directory-local variables never applied.

## Changes

- `denote-directories` now honors a dir-local `denote-directory` that
  has not yet been applied to the buffer. A new helper,
  `denote-directories--dir-local-value`, reads the value from the
  directory-local variables data on demand.
- `denote-link-preview-file` skips the preview when the target does
  not resolve, instead of erroring.

## Technical Details

- The on-demand read uses `hack-dir-local--get-variables`, available
  in Emacs 30 or higher; the call is `fboundp`-guarded, so older
  versions behave exactly as before.
- A buffer-local value or an explicit dynamic binding of
  `denote-directory` still takes precedence, preserving the documented
  let-binding override of `denote-directories`.
- The value is read without the safe-local-variable filter, which is
  equivalent for this variable: its `safe-local-variable` predicate
  accepts any string or list value.

## Testing

- New ERT tests in `tests/denote-test.el`: the unapplied dir-local
  value is honored; a dynamic binding and a buffer-local value each
  take precedence; an unresolvable preview target returns nil without
  error.
- Verified interactively on Emacs 31 with Org 9.8.7: a silo buffer
  with `org-startup-with-link-previews` now initializes fully and
  renders `denote:` image previews.
