### PR TITLE
Move Unix timestamps code in `denote-valid-date-p`

### DIFF
--- a/denote.el
+++ b/denote.el
@@ -3195,6 +3195,12 @@ If DATE is nil or an empty string, return nil."
    ((and (or (numberp date) (listp date))
          (decode-time date))
     date)
+   (; Unix timestamps
+    (when-let* ((stringp date)
+                (_ (string-match "[0-9]\\{10\\}" date))
+                (match (match-string 0 date))
+                (seconds (string-to-number match)))
+      (seconds-to-time seconds)))
    (t ; non-empty strings (e.g. "2024-01-01", "2024-01-01 12:00", etc.)
     (date-to-time (denote--date-add-current-time date)))))
 
@@ -3680,16 +3686,6 @@ here for clarity."
         ((eq prefer-type :string)
          (if date (format-time-string "%F %T" date) ""))))
 
-(defun denote--date-parse-string (date)
-  "Convert DATE to Denote's preferred string format.
-If DATE is a Unix timestamp, convert it accordingly."
-  (if-let* ((_ (string-match "[0-9]\\{10\\}" date)) ; seconds since epoch
-            (match (match-string 0 date))
-            (seconds (string-to-number match))
-            (time (seconds-to-time seconds)))
-      (format-time-string "%Y-%m-%d %H:%M:%S" time)
-    date))
-
 (defun denote-date-prompt (&optional initial-date prompt-text)
   "Prompt for date, expecting YYYY-MM-DD or that plus HH:MM.
 Unix timestamp format is also supported.
@@ -3714,11 +3710,10 @@ a value that can be parsed by `decode-time' or nil."
           (when (string-equal "00" org-time-seconds)
             (setq time (time-add time (string-to-number cur-time-seconds))))
           (format-time-string "%Y-%m-%d %H:%M:%S" time))
-      (denote--date-parse-string
-       (read-string
-        (or prompt-text "DATE and TIME for note (e.g. 2022-06-16 14:30): ")
-        (denote--date-convert initial-date :string)
-        'denote-date-history)))))
+      (read-string
+       (or prompt-text "DATE and TIME for note (e.g. 2022-06-16 14:30): ")
+       (denote--date-convert initial-date :string)
+       'denote-date-history))))
 
 (make-obsolete
  'denote-prompt-for-date-return-id


### PR DESCRIPTION
Hello Prot!

I moved the code about Unix timestamps in `denote-valid-date-p` as I think it makes more sense there. I have not tested, but it should also make `denote-use-date` variable accept Unix timestamps as well.

Have a good day!